### PR TITLE
Adds metadata to backups and more file context

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,6 +22,8 @@ async-timeout==4.0.2
     # via
     #   aiohttp
     #   pyunifiprotect (setup.cfg)
+asyncify==0.9.1
+    # via pyunifiprotect (setup.cfg)
 attrs==22.1.0
     # via
     #   aiohttp
@@ -74,6 +76,8 @@ frozenlist==1.3.1
     # via
     #   aiohttp
     #   aiosignal
+funkify==0.4.4
+    # via asyncify
 greenlet==1.1.3
     # via sqlalchemy
 idna==3.3
@@ -262,6 +266,7 @@ typing-extensions==4.3.0
     #   mypy
     #   pydantic
     #   sqlalchemy2-stubs
+    #   xtyping
 tzdata==2022.2
     # via pytz-deprecation-shim
 tzlocal==4.2
@@ -272,6 +277,8 @@ wheel==0.37.1
     # via pip-tools
 wrapt==1.14.1
     # via astroid
+xtyping==0.6.1
+    # via asyncify
 yarl==1.8.1
     # via aiohttp
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -205,9 +205,7 @@ python-dateutil==2.8.2
 python-dotenv==0.21.0
     # via pyunifiprotect (setup.cfg)
 pytz==2022.2.1
-    # via
-    #   dateparser
-    #   pyunifiprotect (setup.cfg)
+    # via dateparser
 pytz-deprecation-shim==0.1.0.post0
     # via tzlocal
 regex==2022.3.2
@@ -255,8 +253,6 @@ types-aiofiles==22.1.0
 types-dateparser==1.1.4
     # via pyunifiprotect (setup.cfg)
 types-pillow==9.2.1
-    # via pyunifiprotect (setup.cfg)
-types-pytz==2022.2.1.0
     # via pyunifiprotect (setup.cfg)
 types-termcolor==1.1.5
     # via pyunifiprotect (setup.cfg)

--- a/pyunifiprotect/cli/__init__.py
+++ b/pyunifiprotect/cli/__init__.py
@@ -25,7 +25,7 @@ from pyunifiprotect.cli.sensors import app as sensor_app
 from pyunifiprotect.cli.viewers import app as viewer_app
 from pyunifiprotect.data import WSPacket
 from pyunifiprotect.test_util import SampleDataGenerator
-from pyunifiprotect.utils import profile_ws as profile_ws_job
+from pyunifiprotect.utils import get_local_timezone, profile_ws as profile_ws_job
 
 _LOGGER = logging.getLogger("pyunifiprotect")
 
@@ -111,6 +111,9 @@ def main(
     include_unadopted: bool = OPTION_UNADOPTED,
 ) -> None:
     """UniFi Protect CLI"""
+
+    # preload the timezone before any async code runs
+    get_local_timezone()
 
     protect = ProtectApiClient(
         address, port, username, password, verify_ssl=verify, ignore_unadopted=not include_unadopted

--- a/pyunifiprotect/cli/backup.py
+++ b/pyunifiprotect/cli/backup.py
@@ -284,7 +284,7 @@ OPTION_EVENT_FORMAT = typer.Option(
     "{year}/{month}/{day}/{hour}/{datetime}{sep}{mac}{sep}{camera_slug}{event_type}.mp4", "--event-format"
 )
 OPTION_TITLE_FORMAT = typer.Option(
-    "{time_pretty_local} {sep} {camera_name} {sep} {event_type_pretty} {sep} {length_pretty}",
+    "{time_sort_pretty_local} {sep} {camera_name} {sep} {event_type_pretty} {sep} {length_pretty}",
     "--title-format",
 )
 OPTION_VERBOSE = typer.Option(False, "-v", "--verbose", help="Debug logging")

--- a/pyunifiprotect/cli/events.py
+++ b/pyunifiprotect/cli/events.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Callable, List, Optional
 
@@ -12,6 +12,7 @@ from pyunifiprotect import data as d
 from pyunifiprotect.api import ProtectApiClient
 from pyunifiprotect.cli import base
 from pyunifiprotect.exceptions import NvrError
+from pyunifiprotect.utils import local_datetime
 
 app = typer.Typer(rich_markup_mode="rich")
 
@@ -110,8 +111,6 @@ def list_ids(ctx: typer.Context) -> None:
     the TZ environment variable.
     """
 
-    local_tz = datetime.now(timezone.utc).astimezone().tzinfo
-
     require_no_event_id(ctx)
     objs: dict[str, d.Event] = ctx.obj.events
     to_print: list[tuple[str, str, datetime]] = []
@@ -123,7 +122,7 @@ def list_ids(ctx: typer.Context) -> None:
         if len(event_type) > longest_event:
             longest_event = len(event_type)
         dt = obj.timestamp or obj.start
-        dt = dt.astimezone(local_tz)
+        dt = local_datetime(dt)
 
         to_print.append((obj.id, event_type, dt))
 

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -18,9 +18,9 @@ from typing import (
     Union,
 )
 from uuid import UUID
+import zoneinfo
 
 from pydantic.fields import PrivateAttr
-import pytz
 
 from pyunifiprotect.data.base import (
     ProtectBaseObject,
@@ -775,7 +775,7 @@ class NVR(ProtectDeviceModel):
         if "recordingRetentionDurationMs" in data and data["recordingRetentionDurationMs"] is not None:
             data["recordingRetentionDuration"] = timedelta(milliseconds=data.pop("recordingRetentionDurationMs"))
         if "timezone" in data and not isinstance(data["timezone"], tzinfo):
-            data["timezone"] = pytz.timezone(data["timezone"])
+            data["timezone"] = zoneinfo.ZoneInfo(data["timezone"])
 
         return super().unifi_dict_to_dict(data)
 

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -481,7 +481,7 @@ def get_local_timezone() -> tzinfo:
         return TIMEZONE_GLOBAL
 
     try:
-        from homeassistant.util import (  # pylint: disable=import-outside-toplevel  # type: ignore
+        from homeassistant.util import (  # type: ignore  # pylint: disable=import-outside-toplevel
             dt as dt_util,
         )
 

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -439,3 +439,22 @@ def decode_token_cookie(token_cookie: Morsel[str]) -> Dict[str, Any] | None:
     except Exception as broad_ex:  # pylint: disable=broad-except
         _LOGGER.debug("Authentication token decode error: %s", broad_ex)
         return None
+
+
+def format_duration(duration: timedelta) -> str:
+    """Formats a timedelta as a string."""
+
+    seconds = int(duration.total_seconds())
+    hours = seconds // 3600
+    seconds -= hours * 3600
+    minutes = seconds // 60
+    seconds -= minutes * 60
+
+    output = ""
+    if hours > 0:
+        output = f"{hours}h"
+    if minutes > 0:
+        output = f"{output}{minutes}m"
+    output = f"{output}{seconds}s"
+
+    return output

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta, timezone, tzinfo
 from decimal import Decimal
 from enum import Enum
+from hashlib import sha224
 from http.cookies import Morsel
 from inspect import isclass
 from ipaddress import AddressValueError, IPv4Address
@@ -31,6 +32,7 @@ from typing import (
     Union,
 )
 from uuid import UUID
+import zoneinfo
 
 from aiohttp import ClientResponse
 import jwt
@@ -59,6 +61,7 @@ SNAKE_CASE_KEYS = [
     "total_bytes",
     "used_bytes",
 ]
+TIMEZONE_GLOBAL: tzinfo | None = None
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -458,3 +461,62 @@ def format_duration(duration: timedelta) -> str:
     output = f"{output}{seconds}s"
 
     return output
+
+
+def _set_timezone(tz: tzinfo | str) -> tzinfo:
+    global TIMEZONE_GLOBAL  # pylint: disable=global-statement
+
+    if isinstance(tz, str):
+        tz = zoneinfo.ZoneInfo(tz)
+
+    TIMEZONE_GLOBAL = tz
+
+    return TIMEZONE_GLOBAL
+
+
+def get_local_timezone() -> tzinfo:
+    """Gets Olson timezone name for localizing datetimes"""
+
+    if TIMEZONE_GLOBAL is not None:
+        return TIMEZONE_GLOBAL
+
+    try:
+        from homeassistant.util import (  # pylint: disable=import-outside-toplevel
+            dt as dt_util,
+        )
+
+        return _set_timezone(dt_util.DEFAULT_TIME_ZONE)
+    except ImportError:
+        pass
+
+    timezone_name = os.environ.get("TZ")
+    if timezone_name:
+        return _set_timezone(timezone_name)
+
+    timezone_name = "UTC"
+    timezone_locale = Path("/etc/localtime")
+    if timezone_locale.exists():
+        with open(timezone_locale, "rb") as tzfile:
+            tzfile_digest = sha224(tzfile.read()).hexdigest()
+
+        for root, _, filenames in os.walk(Path("/usr/share/zoneinfo/")):
+            for filename in filenames:
+                fullname = os.path.join(root, filename)
+                with open(fullname, "rb") as f:
+                    digest = sha224(f.read()).hexdigest()
+                    if digest == tzfile_digest:
+                        timezone_name = "/".join((fullname.split("/"))[-2:])
+
+    return _set_timezone(timezone_name)
+
+
+def local_datetime(dt: datetime | None = None) -> datetime:
+    """Returns datetime in local timezone"""
+
+    if dt is None:
+        dt = datetime.utcnow().replace(tzinfo=zoneinfo.ZoneInfo("UTC"))
+
+    local_tz = get_local_timezone()
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=local_tz)
+    return dt.astimezone(local_tz)

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -481,7 +481,7 @@ def get_local_timezone() -> tzinfo:
         return TIMEZONE_GLOBAL
 
     try:
-        from homeassistant.util import (  # pylint: disable=import-outside-toplevel
+        from homeassistant.util import (  # pylint: disable=import-outside-toplevel  # type: ignore
             dt as dt_util,
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,8 @@ async-timeout==4.0.2
     # via
     #   aiohttp
     #   pyunifiprotect (setup.cfg)
+asyncify==0.9.1
+    # via pyunifiprotect (setup.cfg)
 attrs==22.1.0
     # via aiohttp
 av==9.2.0
@@ -44,6 +46,8 @@ frozenlist==1.3.1
     # via
     #   aiohttp
     #   aiosignal
+funkify==0.4.4
+    # via asyncify
 greenlet==1.1.3
     # via sqlalchemy
 idna==3.3
@@ -132,11 +136,14 @@ typing-extensions==4.3.0
     #   mypy
     #   pydantic
     #   sqlalchemy2-stubs
+    #   xtyping
 tzdata==2022.2
     # via pytz-deprecation-shim
 tzlocal==4.2
     # via dateparser
 wcwidth==0.2.5
     # via prompt-toolkit
+xtyping==0.6.1
+    # via asyncify
 yarl==1.8.1
     # via aiohttp

--- a/requirements.txt
+++ b/requirements.txt
@@ -99,9 +99,7 @@ python-dateutil==2.8.2
 python-dotenv==0.21.0
     # via pyunifiprotect (setup.cfg)
 pytz==2022.2.1
-    # via
-    #   dateparser
-    #   pyunifiprotect (setup.cfg)
+    # via dateparser
 pytz-deprecation-shim==0.1.0.post0
     # via tzlocal
 regex==2022.3.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ install_requires =
     pillow
     pydantic!=1.9.1 # unexpected breaking change
     pyjwt
-    pytz
     typer[all]>0.6
 
 [options.package_data]
@@ -75,7 +74,6 @@ dev =
     types-aiofiles
     types-dateparser
     types-pillow
-    types-pytz
     types-termcolor
 full=
     aiosqlite

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,6 +79,7 @@ dev =
     types-termcolor
 full=
     aiosqlite
+    asyncify
     av
     ipython
     python-dotenv
@@ -90,5 +91,6 @@ shell=
     python-dotenv
 backup=
     aiosqlite
+    asyncify
     av
     sqlalchemy[asyncio,mypy]


### PR DESCRIPTION
* Adds new title value for the file context that is used for writing video metadata by default
* Adds metadata to video files, metadata includes creation time/year/release and the a human friendly title for the file. Title can be controlled by the new `--title-format` parameter. Defaults to `"{time_pretty_local} {sep} {camera_name} {sep} {event_type_pretty} {sep} {length_pretty}"`
* Adds plenty of new fields for file contexts for setting templates for title/output files, including a lot of `_local` fields so you can save files in the same timezone as the camera
* Runs verification/metadata operations in a separate thread
* Removes pytz as a main dep since `zoneinfo` is python 3.9+

Note: ideal format for Plex to ingest exported files is:
```
--thumb-format "{year_local}/{month_local}/{day_local}/{hour_local}/{title}.jpg" --event-format "{year_local}/{month_local}/{day_local}/{hour_local}/{title}.mp4"
```