### PR TITLE
Adds support for animated-thumbnail endpoint

### DIFF
--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -1145,7 +1145,9 @@ class ProtectApiClient(BaseApiClient):
         retry_timeout: int = RETRY_TIMEOUT,
     ) -> Optional[bytes]:
         """
-        Gets given thumbanil from a given event
+        Gets given thumbanail from a given event.
+
+        Thumbnail response is a JPEG image.
 
         Note: thumbnails / heatmaps do not generate _until after the event ends_. Events that last longer then
         your retry timeout will always return 404.
@@ -1165,13 +1167,50 @@ class ProtectApiClient(BaseApiClient):
             f"events/{thumbnail_id}/thumbnail", params=params, retry_timeout=retry_timeout
         )
 
+    async def get_event_animated_thumbnail(
+        self,
+        thumbnail_id: str,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+        *,
+        speedup: int = 10,
+        retry_timeout: int = RETRY_TIMEOUT,
+    ) -> Optional[bytes]:
+        """
+        Gets given animated thumbanil from a given event.
+
+        Animated thumbnail response is a GIF image.
+
+        Note: thumbnails / do not generate _until after the event ends_. Events that last longer then
+        your retry timeout will always return 404.
+        """
+
+        params: Dict[str, Any] = {
+            "keyFrameOnly": "true",
+            "speedup": speedup,
+        }
+
+        if width is not None:
+            params.update({"w": width})
+
+        if height is not None:
+            params.update({"h": height})
+
+        # old thumbnail URL use thumbnail ID, which is just `e-{event_id}`
+        thumbnail_id = thumbnail_id.replace("e-", "")
+        return await self._get_image_with_retry(
+            f"events/{thumbnail_id}/animated-thumbnail", params=params, retry_timeout=retry_timeout
+        )
+
     async def get_event_heatmap(
         self,
         heatmap_id: str,
         retry_timeout: int = RETRY_TIMEOUT,
     ) -> Optional[bytes]:
         """
-        Gets given heatmap from a given event
+        Gets given heatmap from a given event.
+
+        Heatmap response is a PNG image.
 
         Note: thumbnails / heatmaps do not generate _until after the event ends_. Events that last longer then
         your retry timeout will always return None.

--- a/pyunifiprotect/cli/events.py
+++ b/pyunifiprotect/cli/events.py
@@ -159,9 +159,31 @@ def save_thumbnail(
 
 
 @app.command()
+def save_animated_thumbnail(
+    ctx: typer.Context,
+    output_path: Path = typer.Argument(..., help="GIF format"),
+) -> None:
+    """Saves animated thumbnail for event.
+
+    Only for ring, motion and smartDetectZone events.
+    """
+
+    require_event_id(ctx)
+    event: d.Event = ctx.obj.event
+
+    thumbnail = base.run(ctx, event.get_animated_thumbnail())
+    if thumbnail is None:
+        typer.secho("Could not get thumbnail", fg="red")
+        raise typer.Exit(1)
+
+    with open(output_path, "wb") as f:
+        f.write(thumbnail)
+
+
+@app.command()
 def save_heatmap(
     ctx: typer.Context,
-    output_path: Path = typer.Argument(..., help="JPEG format"),
+    output_path: Path = typer.Argument(..., help="PNG format"),
 ) -> None:
     """
     Saves heatmap for event.

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -268,6 +268,17 @@ class Event(ProtectModelWithId):
             raise NotAuthorized(f"Do not have permission to read media for camera: {self.id}")
         return await self.api.get_event_thumbnail(self.thumbnail_id, width, height)
 
+    async def get_animated_thumbnail(
+        self, width: Optional[int] = None, height: Optional[int] = None, *, speedup: int = 10
+    ) -> Optional[bytes]:
+        """Gets animated thumbnail for event"""
+
+        if self.thumbnail_id is None:
+            return None
+        if not self.api.bootstrap.auth_user.can(ModelType.CAMERA, PermissionNode.READ_MEDIA, self.camera):
+            raise NotAuthorized(f"Do not have permission to read media for camera: {self.id}")
+        return await self.api.get_event_animated_thumbnail(self.thumbnail_id, width, height, speedup=speedup)
+
     async def get_heatmap(self) -> Optional[bytes]:
         """Gets heatmap for event"""
 


### PR DESCRIPTION
* Adds `get_event_animated_thumbnail` and `get_animated_thumbnail` methods for API and Event objects
* Adds `save-animated-thumbnail` to events CLI
* Adds exporting animated thumbnails in events backup
* Adds option to disable thumbnail/animated thumbnail/video download in events backup
* Decreases the default number of download slots from 10 to 5 (animated thumbnail generation is hard on the NVR)