### PR TITLE
Adds tzdata to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ARG PYUFP_VERSION
 COPY --from=builder /usr/local/bin/ /usr/local/bin/
 COPY --from=builder /usr/local/lib/python3.10/ /usr/local/lib/python3.10/
 COPY . /tmp/pyunifiprotect
-RUN SETUPTOOLS_SCM_PRETEND_VERSION=${PYUFP_VERSION} pip install /tmp/pyunifiprotect \
+RUN SETUPTOOLS_SCM_PRETEND_VERSION=${PYUFP_VERSION} pip install -U "/tmp/pyunifiprotect[tz]" \
     && mv /tmp/pyunifiprotect/.docker/entrypoint.sh /usr/local/bin/entrypoint \
     && chmod +x /usr/local/bin/entrypoint \
     && rm /tmp/pyunifiprotect -rf \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -42,8 +42,18 @@ build==0.8.0
     # via
     #   pip-tools
     #   pyunifiprotect (pyproject.toml)
+cairocffi==1.3.0
+    # via cairosvg
+cairosvg==2.5.2
+    # via mkdocs-material
+certifi==2022.6.15.1
+    # via requests
+cffi==1.15.1
+    # via cairocffi
 charset-normalizer==2.1.1
-    # via aiohttp
+    # via
+    #   aiohttp
+    #   requests
 click==8.1.3
     # via
     #   black
@@ -58,10 +68,14 @@ coverage[toml]==6.4.4
     # via
     #   pytest-cov
     #   pyunifiprotect (pyproject.toml)
+cssselect2==0.6.0
+    # via cairosvg
 dateparser==1.1.1
     # via pyunifiprotect (pyproject.toml)
 decorator==5.1.1
     # via ipython
+defusedxml==0.7.1
+    # via cairosvg
 dill==0.3.5.1
     # via pylint
 execnet==1.9.0
@@ -92,7 +106,9 @@ greenlet==1.1.3
 griffe==0.22.1
     # via mkdocstrings-python
 idna==3.3
-    # via yarl
+    # via
+    #   requests
+    #   yarl
 importlib-metadata==4.12.0
     # via mkdocs
 iniconfig==1.1.1
@@ -145,7 +161,7 @@ mkdocs-git-revision-date-localized-plugin==1.1.0
     # via pyunifiprotect (pyproject.toml)
 mkdocs-include-markdown-plugin==3.7.1
     # via pyunifiprotect (pyproject.toml)
-mkdocs-material==8.4.3
+mkdocs-material==8.5.0
     # via pyunifiprotect (pyproject.toml)
 mkdocs-material-extensions==1.0.3
     # via mkdocs-material
@@ -187,7 +203,10 @@ pexpect==4.8.0
 pickleshare==0.7.5
     # via ipython
 pillow==9.2.0
-    # via pyunifiprotect (pyproject.toml)
+    # via
+    #   cairosvg
+    #   mkdocs-material
+    #   pyunifiprotect (pyproject.toml)
 pip-tools==6.8.0
     # via pyunifiprotect (pyproject.toml)
 platformdirs==2.5.2
@@ -210,6 +229,8 @@ py-cpuinfo==8.0.0
     # via pytest-benchmark
 pycodestyle==2.9.1
     # via flake8
+pycparser==2.21
+    # via cffi
 pydantic==1.10.2
     # via pyunifiprotect (pyproject.toml)
 pydocstyle==6.1.1
@@ -284,6 +305,8 @@ pyyaml-env-tag==0.1
     # via mkdocs
 regex==2022.3.2
     # via dateparser
+requests==2.28.1
+    # via mkdocs-material
 rich==12.5.1
     # via typer
 shellingham==1.5.0
@@ -302,10 +325,14 @@ sqlalchemy2-stubs==0.0.2a27
     # via sqlalchemy
 stack-data==0.5.0
     # via ipython
-termcolor==2.0.0
+termcolor==2.0.1
     # via
     #   pytest-sugar
     #   pyunifiprotect (pyproject.toml)
+tinycss2==1.1.1
+    # via
+    #   cairosvg
+    #   cssselect2
 tomli==2.0.1
     # via
     #   black
@@ -318,7 +345,7 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.11.4
     # via pylint
-traitlets==5.3.0
+traitlets==5.4.0
     # via
     #   ipython
     #   matplotlib-inline
@@ -340,15 +367,23 @@ typing-extensions==4.3.0
     #   sqlalchemy2-stubs
     #   xtyping
 tzdata==2022.2
-    # via pytz-deprecation-shim
+    # via
+    #   pytz-deprecation-shim
+    #   pyunifiprotect (pyproject.toml)
 tzlocal==4.2
     # via dateparser
+urllib3==1.26.12
+    # via requests
 verspec==0.1.0
     # via mike
 watchdog==2.1.9
     # via mkdocs
 wcwidth==0.2.5
     # via prompt-toolkit
+webencodings==0.5.1
+    # via
+    #   cssselect2
+    #   tinycss2
 wheel==0.37.1
     # via pip-tools
 wrapt==1.14.1

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,6 +42,14 @@ A number of commands allow you to enter a datetime as an argument or output file
 TZ=America/New_York unifi-protect --help
 ```
 
+!!! note
+
+    If for whatever reason your system does not have then correct timezone data, you can install the `tz` extra to get the data. This just adds the package [tzdata](https://pypi.org/project/tzdata/) as a requirement. It is included by default in the [Docker image](/#using-docker-container).
+
+    ```bash
+    pip install pyunifiprotet[tz]
+    ```
+
 ## Reference
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,7 +47,7 @@ TZ=America/New_York unifi-protect --help
     If for whatever reason your system does not have then correct timezone data, you can install the `tz` extra to get the data. This just adds the package [tzdata](https://pypi.org/project/tzdata/) as a requirement. It is included by default in the [Docker image](/#using-docker-container).
 
     ```bash
-    pip install pyunifiprotet[tz]
+    pip install pyunifiprotect[tz]
     ```
 
 ## Reference

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,9 @@ dev = [
     "types-dateparser",
     "types-pillow",
     "types-termcolor",
+    "tzdata",
 ]
+tz = ["tzdata"]
 full = [
     "aiosqlite",
     "asyncify",

--- a/requirements.txt
+++ b/requirements.txt
@@ -112,9 +112,9 @@ sqlalchemy[asyncio]==1.4.41
     # via pyunifiprotect (pyproject.toml)
 stack-data==0.5.0
     # via ipython
-termcolor==2.0.0
+termcolor==2.0.1
     # via pyunifiprotect (pyproject.toml)
-traitlets==5.3.0
+traitlets==5.4.0
     # via
     #   ipython
     #   matplotlib-inline


### PR DESCRIPTION
The needed timezone data for Python is not in the published docker image. Adds an optional extra that the docker image uses to ensure it is always there. 