### PR TITLE
Updates for UniFi Protect 2.7.15

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "args": [
                 "-u",
                 "shell",
-        ]
+            ]
         },
         {
             "name": "Python: Debug Tests",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "args": [
                 "-u",
                 "shell",
-            ]
+        ]
         },
         {
             "name": "Python: Debug Tests",

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -788,6 +788,8 @@ class WifiConnectionState(WirelessConnectionState):
     # requires 2.7.5+
     ap_name: Optional[str] = None
     experience: Optional[str] = None
+    # requires 2.7.15+
+    connectivity: Optional[str] = None
 
 
 class ProtectAdoptableDeviceModel(ProtectDeviceModel):

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -633,7 +633,7 @@ class Hotplug(ProtectBaseObject):
     video: Optional[bool] = None
 
 
-class FeatureFlags(ProtectBaseObject):
+class CameraFeatureFlags(ProtectBaseObject):
     can_adjust_ir_led_level: bool
     can_magic_zoom: bool
     can_optical_zoom: bool
@@ -748,7 +748,7 @@ class Camera(ProtectMotionDeviceModel):
     privacy_zones: List[CameraZone]
     smart_detect_zones: List[SmartMotionZone]
     stats: CameraStats
-    feature_flags: FeatureFlags
+    feature_flags: CameraFeatureFlags
     pir_settings: PIRSettings
     lcd_message: Optional[LCDMessage]
     lenses: List[CameraLenses]
@@ -2011,6 +2011,10 @@ class Doorlock(ProtectAdoptableDeviceModel):
         await self.api.calibrate_lock(self.id)
 
 
+class ChimeFeatureFlags(ProtectBaseObject):
+    has_wifi: bool
+
+
 class Chime(ProtectAdoptableDeviceModel):
     volume: PercentInt
     is_probing_for_wifi: bool
@@ -2019,6 +2023,8 @@ class Chime(ProtectAdoptableDeviceModel):
     camera_ids: List[str]
     # requires 2.6.17+
     ap_mgmt_ip: Optional[IPv4Address] = None
+    # requires 2.7.15+
+    feature_flags: Optional[ChimeFeatureFlags] = None
 
     # TODO: used for adoption
     # apMac  read only

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -747,7 +747,6 @@ class NVR(ProtectDeviceModel):
     anonymous_device_id: Optional[UUID]
     camera_utilization: int
     is_recycling: bool
-    avg_motions: List[float]
     disable_auto_link: bool
     skip_firmware_update: bool
     location_settings: NVRLocation

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -200,7 +200,7 @@ class SmartDetectObjectType(str, ValuesEnumMixin, enum.Enum):
     VEHICLE = "vehicle"
     FACE = "face"
     PET = "pet"
-    LICENSE_PLATE = "licenseplate"
+    LICENSE_PLATE = "licensePlate"
     PACKAGE = "package"
     # old?
     CAR = "car"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -520,6 +520,13 @@ NEW_FIELDS = {
     "deletedAt",
     "deletionType",
     "lastDisconnect",
+    # 2.7.15
+    "featureFlags",  # added to chime
+}
+
+OLD_FIELDS = {
+    # remove in 2.7.12
+    "avgMotions",
 }
 
 
@@ -589,9 +596,6 @@ def compare_objs(obj_type, expected, actual):
         expected.pop("partition", None)
         expected.pop("deletionType", None)
 
-        # there is a mismatch between licenseplate in SmartDetectTypes and in the event (event has capital P)
-        expected["smartDetectTypes"] = [t.lower() if t == "licensePlate" else t for t in expected["smartDetectTypes"]]
-
         expected_keys = (expected.get("metadata") or {}).keys()
         actual_keys = (actual.get("metadata") or {}).keys()
         # delete all extra metadata keys, many of which are not modeled
@@ -645,6 +649,7 @@ def compare_objs(obj_type, expected, actual):
         expected["wifiConnectionState"]["txRate"] = expected["wifiConnectionState"].get("txRate")
         expected["wifiConnectionState"]["experience"] = expected["wifiConnectionState"].get("experience")
         expected["wifiConnectionState"]["apName"] = expected["wifiConnectionState"].get("apName")
+        expected["wifiConnectionState"]["connectivity"] = expected["wifiConnectionState"].get("connectivity")
 
     # sometimes uptime comes back as a str...
     if "uptime" in expected and expected["uptime"] is not None:
@@ -658,6 +663,9 @@ def compare_objs(obj_type, expected, actual):
     for key in NEW_FIELDS.intersection(actual.keys()):
         if key not in expected:
             del actual[key]
+
+    for key in OLD_FIELDS.intersection(expected.keys()):
+        del expected[key]
 
     assert expected == actual
 


### PR DESCRIPTION
Updates for UniFi Protect 2.7.15:

* Adds `connectivity` field for WiFiConnectionState
* Adds `feature_flags` field for Chime
* Removes `avg_motions` field from NVR (this is technically a breaking change, but for some reason Protect removed the field in a bugfix version...)
* Updates for License Plate smart detection since 2.7.15 finally fixed/standardized it
