### PR TITLE
Updates for UniFi Protect 2.7.18

### DIFF
--- a/pyunifiprotect/cli/chimes.py
+++ b/pyunifiprotect/cli/chimes.py
@@ -85,7 +85,7 @@ def cameras(
             typer.secho(f"Invalid camera ID: {camera_id}")
             raise typer.Exit(1)
 
-        if not camera.feature_flags.has_chime:
+        if not camera.feature_flags.is_doorbell:
             typer.secho(f"Camera is not a doorbell: {camera_id}")
             raise typer.Exit(1)
 

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -223,7 +223,7 @@ class Bootstrap(ProtectBaseObject):
     @property
     def has_doorbell(self) -> bool:
         if self._has_doorbell is None:
-            self._has_doorbell = any(c.feature_flags.has_chime for c in self.cameras.values())
+            self._has_doorbell = any(c.feature_flags.is_doorbell for c in self.cameras.values())
 
         return self._has_doorbell
 

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -674,6 +674,8 @@ class CameraFeatureFlags(ProtectBaseObject):
     lens_type: Optional[LensType] = None
     hotplug: Optional[Hotplug] = None
     smart_detect_audio_types: Optional[List[SmartDetectAudioType]] = None
+    # 2.7.18+
+    is_doorbell: bool
 
     # TODO:
     # focus
@@ -689,6 +691,10 @@ class CameraFeatureFlags(ProtectBaseObject):
             data["smartDetectAudioTypes"] = convert_smart_audio_types(data.pop("smartDetectAudioTypes"))
         if "videoModes" in data:
             data["videoModes"] = convert_video_modes(data.pop("videoModes"))
+
+        # backport support for `is_doorbell` to older versions of Protect
+        if "hasChime" in data and "isDoorbell" not in data:
+            data["isDoorbell"] = data["hasChime"]
 
         return super().unifi_dict_to_dict(data)
 
@@ -2054,7 +2060,7 @@ class Chime(ProtectAdoptableDeviceModel):
     async def add_camera(self, camera: Camera) -> None:
         """Adds new paired camera to chime"""
 
-        if not camera.feature_flags.has_chime:
+        if not camera.feature_flags.is_doorbell:
             raise BadRequest("Camera does not have a chime")
 
         if camera.id in self.camera_ids:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -524,6 +524,17 @@ NEW_FIELDS = {
     "featureFlags",  # added to chime
 }
 
+NEW_CAMERA_FEATURE_FLAGS = {
+    "audio",
+    "audioCodecs",
+    "hasInfrared",
+    "hotplug",
+    "smartDetectAudioTypes",
+    "lensType",
+    # 2.7.18+
+    "isDoorbell",
+}
+
 OLD_FIELDS = {
     # remove in 2.7.12
     "avgMotions",
@@ -561,9 +572,6 @@ def compare_objs(obj_type, expected, actual):
         expected["recordingSettings"]["enableMotionDetection"] = expected["recordingSettings"].get(
             "enableMotionDetection"
         )
-        expected["featureFlags"]["audio"] = expected["featureFlags"].get("audio", [])
-        expected["featureFlags"]["audioCodecs"] = expected["featureFlags"].get("audioCodecs", [])
-        expected["featureFlags"]["hasInfrared"] = expected["featureFlags"].get("hasInfrared")
 
         if expected["eventStats"]["motion"].get("recentHours") in [[None], None, []]:
             expected["eventStats"]["motion"].pop("recentHours", None)
@@ -571,17 +579,12 @@ def compare_objs(obj_type, expected, actual):
         if expected["eventStats"]["smart"].get("recentHours") == [[None], None, []]:
             expected["eventStats"]["smart"].pop("recentHours", None)
             actual["eventStats"]["smart"].pop("recentHours", None)
-        if "hotplug" in actual["featureFlags"] and "hotplug" not in expected["featureFlags"]:
-            del actual["featureFlags"]["hotplug"]
-        if (
-            "smartDetectAudioTypes" in actual["featureFlags"]
-            and "smartDetectAudioTypes" not in expected["featureFlags"]
-        ):
-            del actual["featureFlags"]["smartDetectAudioTypes"]
-        if "lensType" in actual["featureFlags"] and "lensType" not in expected["featureFlags"]:
-            del actual["featureFlags"]["lensType"]
         if "audioTypes" in actual["smartDetectSettings"] and "audioTypes" not in expected["smartDetectSettings"]:
             del actual["smartDetectSettings"]["audioTypes"]
+
+        for flag in NEW_CAMERA_FEATURE_FLAGS:
+            if flag not in expected["featureFlags"]:
+                del actual["featureFlags"][flag]
     elif obj_type == ModelType.USER.value:
         if "settings" in expected:
             expected.pop("settings", None)

--- a/tests/data/test_chime.py
+++ b/tests/data/test_chime.py
@@ -79,7 +79,7 @@ async def test_chime_add_camera(chime_obj: Optional[Chime], camera_obj: Optional
     chime_obj._initial_data = chime_obj.dict()
 
     camera_obj.api.api_request.reset_mock()
-    camera_obj.feature_flags.has_chime = True
+    camera_obj.feature_flags.is_doorbell = True
     camera_obj._initial_data = chime_obj.dict()
 
     await chime_obj.add_camera(camera_obj)
@@ -104,7 +104,7 @@ async def test_chime_add_camera_not_doorbell(chime_obj: Optional[Chime], camera_
     chime_obj._initial_data = chime_obj.dict()
 
     camera_obj.api.api_request.reset_mock()
-    camera_obj.feature_flags.has_chime = False
+    camera_obj.feature_flags.is_doorbell = False
     camera_obj._initial_data = chime_obj.dict()
 
     with pytest.raises(BadRequest):
@@ -126,7 +126,7 @@ async def test_chime_add_camera_exists(chime_obj: Optional[Chime], camera_obj: O
     chime_obj._initial_data = chime_obj.dict()
 
     camera_obj.api.api_request.reset_mock()
-    camera_obj.feature_flags.has_chime = True
+    camera_obj.feature_flags.is_doorbell = True
     camera_obj._initial_data = chime_obj.dict()
 
     with pytest.raises(BadRequest):
@@ -148,7 +148,7 @@ async def test_chime_remove_camera(chime_obj: Optional[Chime], camera_obj: Optio
     chime_obj._initial_data = chime_obj.dict()
 
     camera_obj.api.api_request.reset_mock()
-    camera_obj.feature_flags.has_chime = True
+    camera_obj.feature_flags.is_doorbell = True
     camera_obj._initial_data = chime_obj.dict()
 
     await chime_obj.remove_camera(camera_obj)
@@ -173,7 +173,7 @@ async def test_chime_remove_camera_not_exists(chime_obj: Optional[Chime], camera
     chime_obj._initial_data = chime_obj.dict()
 
     camera_obj.api.api_request.reset_mock()
-    camera_obj.feature_flags.has_chime = True
+    camera_obj.feature_flags.is_doorbell = True
     camera_obj._initial_data = chime_obj.dict()
 
     with pytest.raises(BadRequest):


### PR DESCRIPTION
* Adds new camera feature flag for `is_doorbell` and seperates functionality for `has_chime` and `is_doorbell`. There is an upcoming camera that has no transformer/chime support (G4 DBP PoE).