### PR TITLE
Track every smart detect event seperately

### DIFF
--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -114,6 +114,18 @@ def _process_camera_event(event: Event) -> None:
     dt = getattr(event.camera, dt_attr)
     if dt is None or event.start >= dt or (event.end is not None and event.end >= dt):
         setattr(event.camera, event_attr, event.id)
+        setattr(event.camera, dt_attr, event.start)
+        if event.type in (EventType.SMART_DETECT, EventType.SMART_DETECT_LINE):
+            for smart_type in event.smart_detect_types:
+                event.camera.last_smart_detect_event_ids[smart_type] = event.id
+                event.camera.last_smart_detects[smart_type] = event.start
+        elif event.type == EventType.SMART_AUDIO_DETECT:
+            for smart_type in event.smart_detect_types:
+                audio_type = smart_type.audio_type
+                if audio_type is None:
+                    continue
+                event.camera.last_smart_audio_detect_event_ids[audio_type] = event.id
+                event.camera.last_smart_audio_detects[audio_type] = event.start
 
 
 @dataclass

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -827,6 +827,10 @@ class Camera(ProtectMotionDeviceModel):
     last_smart_audio_detect: Optional[datetime] = None
     last_smart_detect_event_id: Optional[str] = None
     last_smart_audio_detect_event_id: Optional[str] = None
+    last_smart_detects: dict[SmartDetectObjectType, datetime] = {}
+    last_smart_audio_detects: dict[SmartDetectAudioType, datetime] = {}
+    last_smart_detect_event_ids: dict[SmartDetectObjectType, str] = {}
+    last_smart_audio_detect_event_ids: dict[SmartDetectAudioType, str] = {}
     talkback_stream: Optional[TalkbackStream] = None
     _last_ring_timeout: Optional[datetime] = PrivateAttr(None)
 
@@ -844,6 +848,10 @@ class Camera(ProtectMotionDeviceModel):
             "last_smart_audio_detect",
             "last_smart_detect_event_id",
             "last_smart_audio_detect_event_id",
+            "last_smart_detects",
+            "last_smart_audio_detects",
+            "last_smart_detect_event_ids",
+            "last_smart_audio_detect_event_ids",
             "talkback_stream",
         }
 
@@ -946,17 +954,135 @@ class Camera(ProtectMotionDeviceModel):
 
     @property
     def last_smart_detect_event(self) -> Optional[Event]:
+        """Get the last smart detect event id."""
+
         if self.last_smart_detect_event_id is None:
             return None
 
         return self.api.bootstrap.events.get(self.last_smart_detect_event_id)
 
+    def get_last_smart_detect_event(self, smart_type: SmartDetectObjectType) -> Optional[Event]:
+        """Get the last smart detect event for given type."""
+
+        event_id = self.last_smart_detect_event_ids.get(smart_type)
+        if event_id is None:
+            return None
+
+        return self.api.bootstrap.events.get(event_id)
+
+    @property
+    def last_person_detect_event(self) -> Optional[Event]:
+        """Get the last person smart detection event."""
+
+        return self.get_last_smart_detect_event(SmartDetectObjectType.PERSON)
+
+    @property
+    def last_person_detect(self) -> Optional[datetime]:
+        """Get the last person smart detection event."""
+
+        return self.last_smart_detects.get(SmartDetectObjectType.PERSON)
+
+    @property
+    def last_vehicle_detect_event(self) -> Optional[Event]:
+        """Get the last vehicle smart detection event."""
+
+        return self.get_last_smart_detect_event(SmartDetectObjectType.VEHICLE)
+
+    @property
+    def last_vehicle_detect(self) -> Optional[datetime]:
+        """Get the last vehicle smart detection event."""
+
+        return self.last_smart_detects.get(SmartDetectObjectType.VEHICLE)
+
+    @property
+    def last_package_detect_event(self) -> Optional[Event]:
+        """Get the last package smart detection event."""
+
+        return self.get_last_smart_detect_event(SmartDetectObjectType.PACKAGE)
+
+    @property
+    def last_package_detect(self) -> Optional[datetime]:
+        """Get the last package smart detection event."""
+
+        return self.last_smart_detects.get(SmartDetectObjectType.PACKAGE)
+
+    @property
+    def last_face_detect_event(self) -> Optional[Event]:
+        """Get the last face smart detection event."""
+
+        return self.get_last_smart_detect_event(SmartDetectObjectType.FACE)
+
+    @property
+    def last_face_detect(self) -> Optional[datetime]:
+        """Get the last face smart detection event."""
+
+        return self.last_smart_detects.get(SmartDetectObjectType.FACE)
+
+    @property
+    def last_pet_detect_event(self) -> Optional[Event]:
+        """Get the last pet smart detection event."""
+
+        return self.get_last_smart_detect_event(SmartDetectObjectType.PET)
+
+    @property
+    def last_pet_detect(self) -> Optional[datetime]:
+        """Get the last pet smart detection event."""
+
+        return self.last_smart_detects.get(SmartDetectObjectType.PET)
+
+    @property
+    def last_license_plate_detect_event(self) -> Optional[Event]:
+        """Get the last license plate smart detection event."""
+
+        return self.get_last_smart_detect_event(SmartDetectObjectType.LICENSE_PLATE)
+
+    @property
+    def last_license_plate_detect(self) -> Optional[datetime]:
+        """Get the last license plate smart detection event."""
+
+        return self.last_smart_detects.get(SmartDetectObjectType.LICENSE_PLATE)
+
     @property
     def last_smart_audio_detect_event(self) -> Optional[Event]:
+        """Get the last smart audio detect event id."""
+
         if self.last_smart_audio_detect_event_id is None:
             return None
 
         return self.api.bootstrap.events.get(self.last_smart_audio_detect_event_id)
+
+    def get_last_smart_audio_detect_event(self, smart_type: SmartDetectAudioType) -> Optional[Event]:
+        """Get the last smart audio detect event for given type."""
+
+        event_id = self.last_smart_audio_detect_event_ids.get(smart_type)
+        if event_id is None:
+            return None
+
+        return self.api.bootstrap.events.get(event_id)
+
+    @property
+    def last_smoke_detect_event(self) -> Optional[Event]:
+        """Get the last person smart detection event."""
+
+        return self.get_last_smart_audio_detect_event(SmartDetectAudioType.SMOKE)
+
+    @property
+    def last_smoke_detect(self) -> Optional[datetime]:
+        """Get the last smoke smart detection event."""
+
+        return self.last_smart_audio_detects.get(SmartDetectAudioType.SMOKE)
+
+    @property
+    def last_cmonx_detect_event(self) -> Optional[Event]:
+        """Get the last cmonx smart detection event."""
+
+        return self.get_last_smart_audio_detect_event(SmartDetectAudioType.CMONX)
+
+    @property
+    def last_cmonx_detect(self) -> Optional[datetime]:
+        """Get the last cmonx smart detection event."""
+
+        return self.last_smart_audio_detects.get(SmartDetectAudioType.CMONX)
 
     @property
     def timelapse_url(self) -> str:

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -210,6 +210,14 @@ class SmartDetectObjectType(str, ValuesEnumMixin, enum.Enum):
     SMOKE = "alrmSmoke"
     CMONX = "alrmCmonx"
 
+    @property
+    def audio_type(self) -> Optional[SmartDetectAudioType]:
+        if self == SmartDetectObjectType.SMOKE:
+            return SmartDetectAudioType.SMOKE
+        if self == SmartDetectObjectType.CMONX:
+            return SmartDetectAudioType.CMONX
+        return None
+
 
 @enum.unique
 class SmartDetectAudioType(str, ValuesEnumMixin, enum.Enum):


### PR DESCRIPTION
Previously if multiple smart detections were detected at the same time, it would bundle multiple smart detection types into a single event. It looks like newer versions of Protect do the opposite, one event per smart detection type. 

Using the logic to only track the latest ones means that it cannot detect multiple smart detect events if they overlap with each other. This refactors everything to track all of the different types separately.