### PR TITLE
Update stream.py to not require AAC encoder

### DIFF
--- a/pyunifiprotect/stream.py
+++ b/pyunifiprotect/stream.py
@@ -132,7 +132,7 @@ class TalkbackStream(FfmpegCommand):
         cmd = (
             "-loglevel info -hide_banner "
             f'{input_args}-i "{content_url}" -vn '
-            f"-acodec {camera.talkback_settings.type_fmt} -ac {camera.talkback_settings.channels} "
+            f"-ac {camera.talkback_settings.channels} "
             f"-ar {camera.talkback_settings.sampling_rate} -b:a {bitrate} -map 0:a "
             f'-f adts "udp://{camera.host}:{camera.talkback_settings.bind_port}?bitrate={udp_bitrate}"'
         )


### PR DESCRIPTION
From a recent HA update, 2023.6 it seems using the speaker of the device no longer works due to a missing AAC encoder as mentioned here, https://github.com/home-assistant/core/issues/94378

Credit to @band8266 for this fix. Ive tested and confirmed this works on my speakers by patching pyunifiprotect