### PR TITLE
Fixes talkback stream in Python 3.11

### DIFF
--- a/pyunifiprotect/stream.py
+++ b/pyunifiprotect/stream.py
@@ -132,7 +132,7 @@ class TalkbackStream(FfmpegCommand):
         cmd = (
             "-loglevel info -hide_banner "
             f'{input_args}-i "{content_url}" -vn '
-            f"-acodec {camera.talkback_settings.type_fmt} -ac {camera.talkback_settings.channels} "
+            f"-acodec {camera.talkback_settings.type_fmt.value} -ac {camera.talkback_settings.channels} "
             f"-ar {camera.talkback_settings.sampling_rate} -b:a {bitrate} -map 0:a "
             f'-f adts "udp://{camera.host}:{camera.talkback_settings.bind_port}?bitrate={udp_bitrate}"'
         )


### PR DESCRIPTION
Python 3.11 changed how enums are cast to strings.