### PR TITLE
Add pydantic v1 shims to allow pydantic v2

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,9 +12,13 @@ aioshutil==1.3
     # via pyunifiprotect (pyproject.toml)
 aiosignal==1.3.1
     # via aiohttp
-aiosqlite==0.18.0
+aiosqlite==0.19.0
     # via pyunifiprotect (pyproject.toml)
-astroid==2.15.2
+annotated-types==0.5.0
+    # via
+    #   pydantic
+    #   xtyping
+astroid==2.15.5
     # via pylint
 asttokens==2.2.1
     # via stack-data
@@ -22,7 +26,7 @@ async-timeout==4.0.2
     # via
     #   aiohttp
     #   pyunifiprotect (pyproject.toml)
-asyncify==0.9.1
+asyncify==0.9.2
     # via pyunifiprotect (pyproject.toml)
 attrs==23.1.0
     # via aiohttp
@@ -40,7 +44,7 @@ build==0.10.0
     # via
     #   pip-tools
     #   pyunifiprotect (pyproject.toml)
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 charset-normalizer==3.1.0
     # via
@@ -57,9 +61,7 @@ colorama==0.4.6
     #   griffe
     #   mkdocs-material
     #   typer
-commonmark==0.9.1
-    # via rich
-coverage[toml]==7.2.3
+coverage[toml]==7.2.7
     # via
     #   pytest-cov
     #   pyunifiprotect (pyproject.toml)
@@ -84,7 +86,7 @@ frozenlist==1.3.3
     # via
     #   aiohttp
     #   aiosignal
-funkify==0.4.4
+funkify==0.4.5
     # via asyncify
 ghp-import==2.1.0
     # via mkdocs
@@ -94,7 +96,7 @@ gitpython==3.1.31
     # via mkdocs-git-revision-date-localized-plugin
 greenlet==2.0.2
     # via sqlalchemy
-griffe==0.27.1
+griffe==0.29.1
     # via mkdocstrings-python
 idna==3.4
     # via
@@ -102,7 +104,7 @@ idna==3.4
     #   yarl
 iniconfig==2.0.0
     # via pytest
-ipython==8.12.0
+ipython==8.14.0
     # via pyunifiprotect (pyproject.toml)
 isort==5.12.0
     # via pylint
@@ -123,7 +125,9 @@ markdown==3.3.7
     #   mkdocs-material
     #   mkdocstrings
     #   pymdown-extensions
-markupsafe==2.1.2
+markdown-it-py==3.0.0
+    # via rich
+markupsafe==2.1.3
     # via
     #   jinja2
     #   mkdocstrings
@@ -133,11 +137,13 @@ mccabe==0.7.0
     # via
     #   flake8
     #   pylint
+mdurl==0.1.2
+    # via markdown-it-py
 mergedeep==1.3.4
     # via mkdocs
 mike==1.1.2
     # via pyunifiprotect (pyproject.toml)
-mkdocs==1.4.2
+mkdocs==1.4.3
     # via
     #   mike
     #   mkdocs-autorefs
@@ -150,21 +156,21 @@ mkdocs-git-revision-date-localized-plugin==1.2.0
     # via pyunifiprotect (pyproject.toml)
 mkdocs-include-markdown-plugin==4.0.4
     # via pyunifiprotect (pyproject.toml)
-mkdocs-material==9.1.6
+mkdocs-material==9.1.17
     # via pyunifiprotect (pyproject.toml)
 mkdocs-material-extensions==1.1.1
     # via mkdocs-material
-mkdocstrings[python]==0.21.2
+mkdocstrings[python]==0.22.0
     # via
     #   mkdocstrings-python
     #   pyunifiprotect (pyproject.toml)
-mkdocstrings-python==0.9.0
+mkdocstrings-python==1.1.2
     # via mkdocstrings
 multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-mypy==1.2.0
+mypy==1.4.1
     # via
     #   pyunifiprotect (pyproject.toml)
     #   sqlalchemy
@@ -172,7 +178,7 @@ mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
-orjson==3.8.10
+orjson==3.9.1
     # via pyunifiprotect (pyproject.toml)
 packaging==23.1
     # via
@@ -194,11 +200,11 @@ pillow==9.5.0
     # via pyunifiprotect (pyproject.toml)
 pip-tools==6.13.0
     # via pyunifiprotect (pyproject.toml)
-platformdirs==3.2.0
+platformdirs==3.8.0
     # via
     #   black
     #   pylint
-pluggy==1.0.0
+pluggy==1.2.0
     # via pytest
 prompt-toolkit==3.0.38
     # via ipython
@@ -210,28 +216,30 @@ py-cpuinfo==9.0.0
     # via pytest-benchmark
 pycodestyle==2.10.0
     # via flake8
-pydantic==1.10.7
+pydantic==2.0
     # via pyunifiprotect (pyproject.toml)
+pydantic-core==2.0.1
+    # via pydantic
 pydocstyle==6.3.0
     # via
     #   flake8-docstrings
     #   pyunifiprotect (pyproject.toml)
 pyflakes==3.0.1
     # via flake8
-pygments==2.15.0
+pygments==2.15.1
     # via
     #   ipython
     #   mkdocs-material
     #   rich
-pyjwt==2.6.0
+pyjwt==2.7.0
     # via pyunifiprotect (pyproject.toml)
-pylint==2.17.2
+pylint==2.17.4
     # via
     #   pylint-strict-informational
     #   pyunifiprotect (pyproject.toml)
 pylint-strict-informational==0.1
     # via pyunifiprotect (pyproject.toml)
-pymdown-extensions==9.11
+pymdown-extensions==10.0.1
     # via
     #   mkdocs-material
     #   mkdocstrings
@@ -239,7 +247,7 @@ pyproject-flake8==6.0.0.post1
     # via pyunifiprotect (pyproject.toml)
 pyproject-hooks==1.0.0
     # via build
-pytest==7.3.1
+pytest==7.4.0
     # via
     #   pytest-asyncio
     #   pytest-benchmark
@@ -252,13 +260,13 @@ pytest-asyncio==0.21.0
     # via pyunifiprotect (pyproject.toml)
 pytest-benchmark==4.0.0
     # via pyunifiprotect (pyproject.toml)
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via pyunifiprotect (pyproject.toml)
 pytest-sugar==0.9.7
     # via pyunifiprotect (pyproject.toml)
 pytest-timeout==2.1.0
     # via pyunifiprotect (pyproject.toml)
-pytest-xdist==3.2.1
+pytest-xdist==3.3.1
     # via pyunifiprotect (pyproject.toml)
 python-dateutil==2.8.2
     # via
@@ -270,8 +278,6 @@ pytz==2023.3
     # via
     #   dateparser
     #   mkdocs-git-revision-date-localized-plugin
-pytz-deprecation-shim==0.1.0.post0
-    # via tzlocal
 pyyaml==6.0
     # via
     #   mike
@@ -280,13 +286,13 @@ pyyaml==6.0
     #   pyyaml-env-tag
 pyyaml-env-tag==0.1
     # via mkdocs
-regex==2023.3.23
+regex==2023.6.3
     # via
     #   dateparser
     #   mkdocs-material
-requests==2.28.2
+requests==2.31.0
     # via mkdocs-material
-rich==12.6.0
+rich==13.4.2
     # via typer
 shellingham==1.5.0.post1
     # via typer
@@ -298,43 +304,47 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via pydocstyle
-sqlalchemy[asyncio,mypy]==2.0.9
+sqlalchemy[asyncio,mypy]==2.0.17
     # via pyunifiprotect (pyproject.toml)
 stack-data==0.6.2
     # via ipython
-termcolor==2.2.0
+termcolor==2.3.0
     # via
     #   pytest-sugar
     #   pyunifiprotect (pyproject.toml)
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via pylint
 traitlets==5.9.0
     # via
     #   ipython
     #   matplotlib-inline
-typer[all]==0.7.0
+typer[all]==0.9.0
     # via pyunifiprotect (pyproject.toml)
-types-aiofiles==23.1.0.1
+types-aiofiles==23.1.0.4
     # via pyunifiprotect (pyproject.toml)
+types-cryptography==3.3.23.2
+    # via types-pyjwt
 types-dateparser==1.1.4.9
     # via pyunifiprotect (pyproject.toml)
-types-pillow==9.5.0.0
+types-pillow==9.5.0.5
+    # via pyunifiprotect (pyproject.toml)
+types-pyjwt==1.7.1
     # via pyunifiprotect (pyproject.toml)
 types-termcolor==1.1.6.2
     # via pyunifiprotect (pyproject.toml)
-typing-extensions==4.5.0
+typing-extensions==4.7.0
     # via
     #   mypy
     #   pydantic
+    #   pydantic-core
     #   sqlalchemy
+    #   typer
     #   xtyping
 tzdata==2023.3
-    # via
-    #   pytz-deprecation-shim
-    #   pyunifiprotect (pyproject.toml)
-tzlocal==4.3
+    # via pyunifiprotect (pyproject.toml)
+tzlocal==5.0.1
     # via dateparser
-urllib3==1.26.15
+urllib3==2.0.3
     # via requests
 verspec==0.1.0
     # via mike
@@ -346,9 +356,9 @@ wheel==0.40.0
     # via pip-tools
 wrapt==1.15.0
     # via astroid
-xtyping==0.6.2
+xtyping==0.7.0
     # via asyncify
-yarl==1.8.2
+yarl==1.9.2
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "orjson",
     "packaging",
     "pillow",
-    "pydantic!=1.9.1,<2",
+    "pydantic!=1.9.1",
     "pyjwt",
     "typer[all]>0.6",
 ]
@@ -83,6 +83,7 @@ dev = [
     "types-aiofiles",
     "types-dateparser",
     "types-pillow",
+    "types-pyjwt",
     "types-termcolor",
     "tzdata",
 ]

--- a/pyunifiprotect/cli/base.py
+++ b/pyunifiprotect/cli/base.py
@@ -6,12 +6,16 @@ from enum import Enum
 from typing import Any, Callable, Coroutine, Mapping, Optional, Sequence, TypeVar
 
 import orjson
-from pydantic import ValidationError
 import typer
 
 from pyunifiprotect.api import ProtectApiClient
 from pyunifiprotect.data import NVR, ProtectAdoptableDeviceModel, ProtectBaseObject
 from pyunifiprotect.exceptions import BadRequest, NvrError, StreamError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError  # type: ignore
 
 T = TypeVar("T")
 

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -21,9 +21,6 @@ from typing import (
 )
 from uuid import UUID
 
-from pydantic import BaseModel
-from pydantic.fields import SHAPE_DICT, SHAPE_LIST, PrivateAttr
-
 from pyunifiprotect.data.types import (
     ModelType,
     PercentFloat,
@@ -47,11 +44,21 @@ from pyunifiprotect.utils import (
     to_snake_case,
 )
 
+try:
+    from pydantic.v1 import BaseModel
+    from pydantic.v1.fields import SHAPE_DICT, SHAPE_LIST, PrivateAttr
+except ImportError:
+    from pydantic import BaseModel  # type: ignore
+    from pydantic.fields import SHAPE_DICT, SHAPE_LIST, PrivateAttr  # type: ignore
+
 if TYPE_CHECKING:
     from asyncio.events import TimerHandle
     from typing import Self  # requires Python 3.11+
 
-    from pydantic.typing import DictStrAny, SetStr
+    try:
+        from pydantic.v1.typing import DictStrAny, SetStr
+    except ImportError:
+        from pydantic.typing import DictStrAny, SetStr  # type: ignore
 
     from pyunifiprotect.api import ProtectApiClient
     from pyunifiprotect.data.devices import Bridge
@@ -124,7 +131,7 @@ class ProtectBaseObject(BaseModel):
         return obj
 
     @classmethod
-    def construct(cls, _fields_set: Optional[Set[str]] = None, **values: Any) -> ProtectBaseObject:
+    def construct(cls, _fields_set: Optional[Set[str]] = None, **values: Any) -> Self:
         api = values.pop("api", None)
         values_set = set(values)
 
@@ -558,7 +565,7 @@ class ProtectModelWithId(ProtectModel):
         self._update_event = update_event or asyncio.Event()
 
     @classmethod
-    def construct(cls, _fields_set: Optional[Set[str]] = None, **values: Any) -> ProtectModelWithId:
+    def construct(cls, _fields_set: Optional[Set[str]] = None, **values: Any) -> Self:
         update_lock = values.pop("update_lock", None)
         update_queue = values.pop("update_queue", None)
         update_event = values.pop("update_event", None)

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -10,7 +10,11 @@ from typing import Any, Dict, List, Optional, Set, Tuple, cast
 from uuid import UUID
 
 from aiohttp.client_exceptions import ServerDisconnectedError
-from pydantic import PrivateAttr, ValidationError
+
+try:
+    from pydantic.v1 import PrivateAttr, ValidationError
+except ImportError:
+    from pydantic import PrivateAttr, ValidationError  # type: ignore
 
 from pyunifiprotect.data.base import (
     RECENT_EVENT_MAX,

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -11,7 +11,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
 from uuid import UUID
 
-from pydantic.fields import PrivateAttr
+try:
+    from pydantic.v1.fields import PrivateAttr
+except ImportError:
+    from pydantic.fields import PrivateAttr
 
 from pyunifiprotect.data.base import (
     EVENT_PING_INTERVAL,
@@ -625,7 +628,7 @@ class CameraZone(ProtectBaseObject):
     @staticmethod
     def create_privacy_zone(zone_id: int) -> CameraZone:
         return CameraZone(
-            id=zone_id, name=PRIVACY_ZONE_NAME, color=Color("#85BCEC"), points=[[0, 0], [1, 0], [1, 1], [0, 1]]
+            id=zone_id, name=PRIVACY_ZONE_NAME, color=Color("#85BCEC"), points=[[0, 0], [1, 0], [1, 1], [0, 1]]  # type: ignore
         )
 
 
@@ -1700,7 +1703,7 @@ class Camera(ProtectMotionDeviceModel):
             reset_at = utc_now() + self.api.bootstrap.nvr.doorbell_settings.default_message_reset_timeout
 
         def callback() -> None:
-            self.lcd_message = LCDMessage(api=self._api, type=text_type, text=text, reset_at=reset_at)
+            self.lcd_message = LCDMessage(api=self._api, type=text_type, text=text, reset_at=reset_at)  # type: ignore
 
         await self.queue_update(callback)
 

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -25,7 +25,6 @@ import zoneinfo
 import aiofiles
 from aiofiles import os as aos
 import orjson
-from pydantic.fields import PrivateAttr
 
 from pyunifiprotect.data.base import (
     ProtectBaseObject,
@@ -58,8 +57,17 @@ from pyunifiprotect.data.user import User, UserLocation
 from pyunifiprotect.exceptions import BadRequest, NotAuthorized
 from pyunifiprotect.utils import RELEASE_CACHE, process_datetime
 
+try:
+    from pydantic.v1.fields import PrivateAttr
+except ImportError:
+    from pydantic.fields import PrivateAttr
+
 if TYPE_CHECKING:
-    from pydantic.typing import SetStr
+    try:
+        from pydantic.v1.typing import SetStr
+    except ImportError:
+        from pydantic.typing import SetStr  # type: ignore
+
 
 _LOGGER = logging.getLogger(__name__)
 MAX_SUPPORTED_CAMERAS = 256
@@ -877,11 +885,11 @@ class NVR(ProtectDeviceModel):
         self.doorbell_settings.all_messages = [
             DoorbellMessage(
                 type=DoorbellMessageType.LEAVE_PACKAGE_AT_DOOR,
-                text=DoorbellMessageType.LEAVE_PACKAGE_AT_DOOR.value.replace("_", " "),
+                text=DoorbellMessageType.LEAVE_PACKAGE_AT_DOOR.value.replace("_", " "),  # type: ignore
             ),
             DoorbellMessage(
                 type=DoorbellMessageType.DO_NOT_DISTURB,
-                text=DoorbellMessageType.DO_NOT_DISTURB.value.replace("_", " "),
+                text=DoorbellMessageType.DO_NOT_DISTURB.value.replace("_", " "),  # type: ignore
             ),
             *(
                 DoorbellMessage(

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -14,9 +14,15 @@ from typing import (
 )
 
 from packaging.version import Version as BaseVersion
-from pydantic import ConstrainedInt
-from pydantic.color import Color as BaseColor
-from pydantic.types import ConstrainedFloat, ConstrainedStr
+
+try:
+    from pydantic.v1 import ConstrainedInt
+    from pydantic.v1.color import Color as BaseColor
+    from pydantic.v1.types import ConstrainedFloat, ConstrainedStr
+except ImportError:
+    from pydantic import ConstrainedInt  # type: ignore
+    from pydantic.color import Color as BaseColor  # type: ignore
+    from pydantic.types import ConstrainedFloat, ConstrainedStr  # type: ignore
 
 KT = TypeVar("KT")
 VT = TypeVar("VT")

--- a/pyunifiprotect/data/user.py
+++ b/pyunifiprotect/data/user.py
@@ -5,7 +5,10 @@ from datetime import datetime
 from functools import cache
 from typing import Any, Dict, List, Optional, Set
 
-from pydantic.fields import PrivateAttr
+try:
+    from pydantic.v1.fields import PrivateAttr
+except ImportError:
+    from pydantic.fields import PrivateAttr
 
 from pyunifiprotect.data.base import ProtectBaseObject, ProtectModel, ProtectModelWithId
 from pyunifiprotect.data.types import ModelType, PermissionNode

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -38,8 +38,6 @@ import zoneinfo
 
 from aiohttp import ClientResponse
 import jwt
-from pydantic.fields import SHAPE_DICT, SHAPE_LIST, SHAPE_SET, ModelField
-from pydantic.utils import to_camel
 
 from pyunifiprotect.data.types import (
     Color,
@@ -49,6 +47,18 @@ from pyunifiprotect.data.types import (
     VideoMode,
 )
 from pyunifiprotect.exceptions import NvrError
+
+try:
+    from pydantic.v1.fields import SHAPE_DICT, SHAPE_LIST, SHAPE_SET, ModelField
+    from pydantic.v1.utils import to_camel
+except ImportError:
+    from pydantic.fields import (  # type: ignore
+        SHAPE_DICT,
+        SHAPE_LIST,
+        SHAPE_SET,
+        ModelField,
+    )
+    from pydantic.utils import to_camel  # type: ignore
 
 if TYPE_CHECKING:
     from pyunifiprotect.api import ProtectApiClient

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,15 +12,19 @@ aioshutil==1.3
     # via pyunifiprotect (pyproject.toml)
 aiosignal==1.3.1
     # via aiohttp
-aiosqlite==0.18.0
+aiosqlite==0.19.0
     # via pyunifiprotect (pyproject.toml)
+annotated-types==0.5.0
+    # via
+    #   pydantic
+    #   xtyping
 asttokens==2.2.1
     # via stack-data
 async-timeout==4.0.2
     # via
     #   aiohttp
     #   pyunifiprotect (pyproject.toml)
-asyncify==0.9.1
+asyncify==0.9.2
     # via pyunifiprotect (pyproject.toml)
 attrs==23.1.0
     # via aiohttp
@@ -34,8 +38,6 @@ click==8.1.3
     # via typer
 colorama==0.4.6
     # via typer
-commonmark==0.9.1
-    # via rich
 dateparser==1.1.8
     # via pyunifiprotect (pyproject.toml)
 decorator==5.1.1
@@ -46,23 +48,27 @@ frozenlist==1.3.3
     # via
     #   aiohttp
     #   aiosignal
-funkify==0.4.4
+funkify==0.4.5
     # via asyncify
 greenlet==2.0.2
     # via sqlalchemy
 idna==3.4
     # via yarl
-ipython==8.12.0
+ipython==8.14.0
     # via pyunifiprotect (pyproject.toml)
 jedi==0.18.2
     # via ipython
+markdown-it-py==3.0.0
+    # via rich
 matplotlib-inline==0.1.6
     # via ipython
+mdurl==0.1.2
+    # via markdown-it-py
 multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-orjson==3.8.10
+orjson==3.9.1
     # via pyunifiprotect (pyproject.toml)
 packaging==23.1
     # via pyunifiprotect (pyproject.toml)
@@ -80,13 +86,15 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pydantic==1.10.7
+pydantic==2.0
     # via pyunifiprotect (pyproject.toml)
-pygments==2.15.0
+pydantic-core==2.0.1
+    # via pydantic
+pygments==2.15.1
     # via
     #   ipython
     #   rich
-pyjwt==2.6.0
+pyjwt==2.7.0
     # via pyunifiprotect (pyproject.toml)
 python-dateutil==2.8.2
     # via dateparser
@@ -94,11 +102,9 @@ python-dotenv==1.0.0
     # via pyunifiprotect (pyproject.toml)
 pytz==2023.3
     # via dateparser
-pytz-deprecation-shim==0.1.0.post0
-    # via tzlocal
-regex==2023.3.23
+regex==2023.6.3
     # via dateparser
-rich==12.6.0
+rich==13.4.2
     # via typer
 shellingham==1.5.0.post1
     # via typer
@@ -106,30 +112,30 @@ six==1.16.0
     # via
     #   asttokens
     #   python-dateutil
-sqlalchemy[asyncio]==2.0.9
+sqlalchemy[asyncio]==2.0.17
     # via pyunifiprotect (pyproject.toml)
 stack-data==0.6.2
     # via ipython
-termcolor==2.2.0
+termcolor==2.3.0
     # via pyunifiprotect (pyproject.toml)
 traitlets==5.9.0
     # via
     #   ipython
     #   matplotlib-inline
-typer[all]==0.7.0
+typer[all]==0.9.0
     # via pyunifiprotect (pyproject.toml)
-typing-extensions==4.5.0
+typing-extensions==4.7.0
     # via
     #   pydantic
+    #   pydantic-core
     #   sqlalchemy
+    #   typer
     #   xtyping
-tzdata==2023.3
-    # via pytz-deprecation-shim
-tzlocal==4.3
+tzlocal==5.0.1
     # via dateparser
 wcwidth==0.2.6
     # via prompt-toolkit
-xtyping==0.6.2
+xtyping==0.7.0
     # via asyncify
-yarl==1.8.2
+yarl==1.9.2
     # via aiohttp

--- a/tests/data/test_camera.py
+++ b/tests/data/test_camera.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 from typing import Optional
 from unittest.mock import Mock, patch
 
-from pydantic.error_wrappers import ValidationError
 import pytest
 
 from pyunifiprotect.data import (
@@ -22,6 +21,11 @@ from pyunifiprotect.data.websocket import WSAction, WSSubscriptionMessage
 from pyunifiprotect.exceptions import BadRequest
 from pyunifiprotect.utils import to_js_time
 from tests.conftest import TEST_CAMERA_EXISTS
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError  # type: ignore
 
 
 @pytest.mark.skipif(not TEST_CAMERA_EXISTS, reason="Missing testdata")

--- a/tests/data/test_chime.py
+++ b/tests/data/test_chime.py
@@ -3,13 +3,17 @@
 
 from typing import Optional
 
-from pydantic.error_wrappers import ValidationError
 import pytest
 
 from pyunifiprotect.data import Camera
 from pyunifiprotect.data.devices import Chime
 from pyunifiprotect.exceptions import BadRequest
 from tests.conftest import TEST_CAMERA_EXISTS, TEST_CHIME_EXISTS
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError  # type: ignore
 
 
 @pytest.mark.skipif(not TEST_CHIME_EXISTS, reason="Missing testdata")

--- a/tests/data/test_common.py
+++ b/tests/data/test_common.py
@@ -163,7 +163,7 @@ def test_camera_smart_events(camera_obj: Camera):
     camera_obj.last_smart_detect_event_ids = {}
     camera_obj.last_smart_detects = {}
     events = [
-        Event(
+        Event(  # type: ignore
             api=camera_obj.api,
             id="test_event_1",
             camera_id=camera_obj.id,
@@ -173,7 +173,7 @@ def test_camera_smart_events(camera_obj: Camera):
             smart_detect_types=[SmartDetectObjectType.PERSON],
             smart_detect_event_ids=[],
         ),
-        Event(
+        Event(  # type: ignore
             api=camera_obj.api,
             id="test_event_2",
             camera_id=camera_obj.id,
@@ -184,7 +184,7 @@ def test_camera_smart_events(camera_obj: Camera):
             smart_detect_types=[SmartDetectObjectType.PACKAGE],
             smart_detect_event_ids=[],
         ),
-        Event(
+        Event(  # type: ignore
             api=camera_obj.api,
             id="test_event_1",
             camera_id=camera_obj.id,
@@ -195,7 +195,7 @@ def test_camera_smart_events(camera_obj: Camera):
             smart_detect_types=[SmartDetectObjectType.PERSON, SmartDetectObjectType.VEHICLE],
             smart_detect_event_ids=[],
         ),
-        Event(
+        Event(  # type: ignore
             api=camera_obj.api,
             id="test_event_3",
             camera_id=camera_obj.id,
@@ -237,7 +237,7 @@ def test_camera_smart_audio_events(camera_obj: Camera):
     camera_obj.last_smart_audio_detect_event_ids = {}
     camera_obj.last_smart_audio_detects = {}
     events = [
-        Event(
+        Event(  # type: ignore
             api=camera_obj.api,
             id="test_event_1",
             camera_id=camera_obj.id,
@@ -247,7 +247,7 @@ def test_camera_smart_audio_events(camera_obj: Camera):
             smart_detect_types=[SmartDetectObjectType.SMOKE],
             smart_detect_event_ids=[],
         ),
-        Event(
+        Event(  # type: ignore
             api=camera_obj.api,
             id="test_event_2",
             camera_id=camera_obj.id,

--- a/tests/data/test_light.py
+++ b/tests/data/test_light.py
@@ -4,7 +4,6 @@
 from datetime import timedelta
 from typing import Optional
 
-from pydantic.error_wrappers import ValidationError
 import pytest
 
 from pyunifiprotect.data import Camera, Light
@@ -12,6 +11,11 @@ from pyunifiprotect.data.types import LightModeEnableType, LightModeType
 from pyunifiprotect.exceptions import BadRequest
 from pyunifiprotect.utils import to_ms
 from tests.conftest import TEST_CAMERA_EXISTS, TEST_LIGHT_EXISTS
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError  # type: ignore
 
 
 @pytest.mark.skipif(not TEST_LIGHT_EXISTS, reason="Missing testdata")

--- a/tests/data/test_nvr.py
+++ b/tests/data/test_nvr.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from datetime import timedelta
 from ipaddress import IPv4Address, IPv6Address
 
-from pydantic.error_wrappers import ValidationError
 import pytest
 
 from pyunifiprotect.data import (
@@ -17,6 +16,11 @@ from pyunifiprotect.data import (
 )
 from pyunifiprotect.exceptions import BadRequest
 from pyunifiprotect.utils import to_ms
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError  # type: ignore
 
 
 @pytest.mark.parametrize("status", [True, False])

--- a/tests/data/test_sensor.py
+++ b/tests/data/test_sensor.py
@@ -1,7 +1,5 @@
 # type: ignore
 # pylint: disable=protected-access
-
-from pydantic.error_wrappers import ValidationError
 import pytest
 
 from pyunifiprotect.data import Camera, Light
@@ -9,6 +7,11 @@ from pyunifiprotect.data.devices import Sensor
 from pyunifiprotect.data.types import MountType
 from pyunifiprotect.exceptions import BadRequest
 from tests.conftest import TEST_CAMERA_EXISTS, TEST_SENSOR_EXISTS
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError  # type: ignore
 
 
 @pytest.mark.skipif(not TEST_SENSOR_EXISTS, reason="Missing testdata")


### PR DESCRIPTION
[Pydantic v2 bundled the v1 version with itself](https://github.com/pydantic/pydantic#pydantic-v110-vs-v2), so the first obvious step is to remove the constraint and allow v2 to be installed using the v1 API shim. 

It looks like a lot of the field internals changed so I will have to go back through each import, update them to allow the v2 version and test before we can use v2. It will likely be a breaking change (v5) to get pydantic v2 fully working as much of the "construct" logic may need to be removed or re-written.