### PR TITLE
Strip unused keys in device updates to reduce state writes

### DIFF
--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -380,12 +380,13 @@ class Bootstrap(ProtectBaseObject):
             return None
 
         data = self.nvr.unifi_dict_to_dict(data)
-        old_nvr = self.nvr.copy()
-        self.nvr = self.nvr.update_from_dict(deepcopy(data))
-
+        # nothing left to process
         if not data:
             self._create_stat(packet, [], True)
             return None
+
+        old_nvr = self.nvr.copy()
+        self.nvr = self.nvr.update_from_dict(deepcopy(data))
 
         self._create_stat(packet, list(data), False)
         return WSSubscriptionMessage(

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -375,13 +375,17 @@ class Bootstrap(ProtectBaseObject):
         if ignore_stats:
             _remove_stats_keys(data)
         # nothing left to process
-        if len(data) == 0:
+        if not data:
             self._create_stat(packet, [], True)
             return None
 
         data = self.nvr.unifi_dict_to_dict(data)
         old_nvr = self.nvr.copy()
         self.nvr = self.nvr.update_from_dict(deepcopy(data))
+
+        if not data:
+            self._create_stat(packet, [], True)
+            return None
 
         self._create_stat(packet, list(data), False)
         return WSSubscriptionMessage(
@@ -405,7 +409,7 @@ class Bootstrap(ProtectBaseObject):
         if model_type == "camera" and "lastMotion" in data:
             del data["lastMotion"]
         # nothing left to process
-        if len(data) == 0:
+        if not data:
             self._create_stat(packet, [], True)
             return None
 

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -376,7 +376,7 @@ class Bootstrap(ProtectBaseObject):
         self, packet: WSPacket, data: Dict[str, Any], ignore_stats: bool
     ) -> Optional[WSSubscriptionMessage]:
         if ignore_stats:
-            data = _remove_stats_keys(data)
+            _remove_stats_keys(data)
         # nothing left to process
         if len(data) == 0:
             self._create_stat(packet, [], True)

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -61,10 +61,7 @@ STATS_KEYS = {
     "recordingSchedules",
     "eventStats",
 }
-IGNORE_DEVICE_KEYS = {
-    "nvrMac",
-    "guid"
-}
+IGNORE_DEVICE_KEYS = {"nvrMac", "guid"}
 
 CAMERA_EVENT_ATTR_MAP: Dict[EventType, Tuple[str, str]] = {
     EventType.MOTION: ("last_motion", "last_motion_event_id"),
@@ -75,7 +72,7 @@ CAMERA_EVENT_ATTR_MAP: Dict[EventType, Tuple[str, str]] = {
 }
 
 
-def _remove_stats_keys(data: Dict[str, Any]) -> Dict[str, Any]:
+def _remove_stats_keys(data: Dict[str, Any]) -> None:
     for key in STATS_KEYS.intersection(data):
         del data[key]
 


### PR DESCRIPTION
Adds `nvrMac` and `guid` to the list of keys we ignored as every message for a device attached to an nvr was generating a callback