### PR TITLE
Replace datetime.utcnow

### DIFF
--- a/pyunifiprotect/test_util/__init__.py
+++ b/pyunifiprotect/test_util/__init__.py
@@ -220,7 +220,7 @@ class SampleDataGenerator:
     async def generate_event_data(self) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
         data = await self.client.get_events_raw()
 
-        self.constants["time"] = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()
+        self.constants["time"] = datetime.now(tz=timezone.utc).isoformat()
         self.constants["event_count"] = len(data)
 
         motion_event: Optional[Dict[str, Any]] = None

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -161,7 +161,7 @@ def to_ms(duration: Optional[timedelta]) -> Optional[int]:
 
 
 def utc_now() -> datetime:
-    return datetime.utcnow().replace(tzinfo=timezone.utc)
+    return datetime.now(tz=timezone.utc)
 
 
 def from_js_time(num: Union[int, float, str, datetime]) -> datetime:
@@ -555,7 +555,7 @@ def local_datetime(dt: datetime | None = None) -> datetime:
     """Returns datetime in local timezone"""
 
     if dt is None:
-        dt = datetime.utcnow().replace(tzinfo=zoneinfo.ZoneInfo("UTC"))
+        dt = datetime.now(tz=timezone.utc)
 
     local_tz = get_local_timezone()
     if dt.tzinfo is None:

--- a/tests/data/test_camera.py
+++ b/tests/data/test_camera.py
@@ -1,7 +1,7 @@
 # type: ignore
 # pylint: disable=protected-access
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 from unittest.mock import Mock, patch
 
@@ -634,7 +634,7 @@ async def test_camera_set_lcd_text_custom(camera_obj: Optional[Camera]):
         reset_at=None,
     )
 
-    now = datetime.utcnow()
+    now = datetime.now(tz=timezone.utc)
     await camera_obj.set_lcd_text(DoorbellMessageType.CUSTOM_MESSAGE, "Test", now)
 
     camera_obj.api.api_request.assert_called_with(
@@ -662,7 +662,7 @@ async def test_camera_set_lcd_text_custom_to_custom(camera_obj: Optional[Camera]
         reset_at=None,
     )
 
-    now = datetime.utcnow()
+    now = datetime.now(tz=timezone.utc)
     await camera_obj.set_lcd_text(DoorbellMessageType.CUSTOM_MESSAGE, "Test", now)
 
     camera_obj.api.api_request.assert_called_with(


### PR DESCRIPTION
Starting with Python 3.12 `datetime.utcnow` will be deprecated.
https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcnow