### PR TITLE
Updates for Protect 2.9.20

### DIFF
--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -852,6 +852,10 @@ class ProtectAdoptableDeviceModel(ProtectDeviceModel):
     nvr_mac: Optional[str] = None
     # requires 2.8.22+
     guid: Optional[UUID] = None
+    # requires 2.9.20+
+    is_restoring: Optional[bool] = None
+    last_disconnect: Optional[datetime] = None
+    anonymous_device_id: Optional[UUID] = None
 
     wired_connection_state: Optional[WiredConnectionState] = None
     wifi_connection_state: Optional[WifiConnectionState] = None
@@ -878,6 +882,7 @@ class ProtectAdoptableDeviceModel(ProtectDeviceModel):
             "isAttemptingToConnect",
             "bluetoothConnectionState",
             "isDownloadingFirmware",
+            "anonymousDeviceId",
         }
 
     @classmethod
@@ -902,6 +907,13 @@ class ProtectAdoptableDeviceModel(ProtectDeviceModel):
             del data["bridge"]
 
         return data
+
+    @classmethod
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        if "lastDisconnect" in data and data["lastDisconnect"] is not None:
+            data["lastDisconnect"] = process_datetime(data, "lastDisconnect")
+
+        return super().unifi_dict_to_dict(data)
 
     @property
     def display_name(self) -> str:

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -9,7 +9,6 @@ from ipaddress import IPv4Address
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
-from uuid import UUID
 
 try:
     from pydantic.v1.fields import PrivateAttr
@@ -384,6 +383,9 @@ class RecordingSettings(ProtectBaseObject):
     enable_motion_detection: Optional[bool] = None
     enable_pir_timelapse: bool
     use_new_motion_algorithm: bool
+    # requires 2.9.20+
+    in_schedule_mode: Optional[str] = None
+    out_schedule_mode: Optional[str] = None
 
     @classmethod
     def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
@@ -717,6 +719,11 @@ class CameraFeatureFlags(ProtectBaseObject):
     is_doorbell: bool
     # 2.8.22+
     lens_model: Optional[str] = None
+    # 2.9.20+
+    has_color_lcd_screen: Optional[bool] = None
+    has_line_crossing: Optional[bool] = None
+    has_line_crossing_counting: Optional[bool] = None
+    has_liveview_tracking: Optional[bool] = None
 
     # TODO:
     # focus
@@ -781,7 +788,6 @@ class Camera(ProtectMotionDeviceModel):
     chime_duration: timedelta
     last_ring: Optional[datetime]
     is_live_heatmap_enabled: bool
-    anonymous_device_id: Optional[UUID]
     event_stats: CameraEventStats
     video_reconfiguration_in_progress: bool
     channels: List[CameraChannel]
@@ -823,6 +829,8 @@ class Camera(ProtectMotionDeviceModel):
     use_global: Optional[bool] = None
     # requires 2.8.22+
     user_configured_ap: Optional[bool] = None
+    # requires 2.9.20+
+    has_recordings: Optional[bool] = None
 
     # TODO: used for adopting
     # apMac read only
@@ -831,10 +839,11 @@ class Camera(ProtectMotionDeviceModel):
 
     # TODO:
     # lastPrivacyZonePositionId
-    # recordingSchedule
     # smartDetectLines
     # streamSharing read only
     # stopStreamLevel
+    # uplinkDevice
+    # recordingSchedulesV2
 
     # not directly from UniFi
     last_ring_event_id: Optional[str] = None
@@ -883,7 +892,6 @@ class Camera(ProtectMotionDeviceModel):
             "isProbingForWifi",
             "lastRing",
             "isLiveHeatmapEnabled",
-            "anonymousDeviceId",
             "eventStats",
             "videoReconfigurationInProgress",
             "lenses",
@@ -1811,7 +1819,6 @@ class Viewer(ProtectAdoptableDeviceModel):
     stream_limit: int
     software_version: str
     liveview_id: str
-    anonymous_device_id: Optional[UUID] = None
 
     @classmethod
     @cache
@@ -2276,6 +2283,13 @@ class Doorlock(ProtectAdoptableDeviceModel):
 
 class ChimeFeatureFlags(ProtectBaseObject):
     has_wifi: bool
+    # 2.9.20+
+    has_https_client_ota: Optional[bool] = None
+
+    @classmethod
+    @cache
+    def _get_unifi_remaps(cls) -> Dict[str, str]:
+        return {**super()._get_unifi_remaps(), "hasHttpsClientOTA": "hasHttpsClientOta"}
 
 
 class Chime(ProtectAdoptableDeviceModel):

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -740,6 +740,9 @@ class NVRFeatureFlags(ProtectBaseObject):
     notifications_v2: bool
     homekit_paired: Optional[bool] = None
     ulp_role_management: Optional[bool] = None
+    # 2.9.20+
+    detection_labels: Optional[bool] = None
+    has_two_way_audio_media_streams: Optional[bool] = None
 
 
 class NVR(ProtectDeviceModel):
@@ -804,6 +807,11 @@ class NVR(ProtectDeviceModel):
     public_ip: Optional[IPv4Address] = None
     ulp_version: Optional[str] = None
     wan_ip: Optional[Union[IPv4Address, IPv6Address]] = None
+    # requires 2.9.20+
+    hard_drive_state: Optional[str] = None
+    is_network_installed: Optional[bool] = None
+    is_protect_updatable: Optional[bool] = None
+    is_ucore_updatable: Optional[bool] = None
 
     # TODO:
     # errorCode   read only
@@ -812,6 +820,8 @@ class NVR(ProtectDeviceModel):
     # dbRecoveryOptions
     # globalCameraSettings
     # portStatus
+    # cameraCapacity
+    # deviceFirmwareSettings
 
     @classmethod
     @cache

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -116,10 +116,12 @@ class ModelType(str, ValuesEnumMixin, enum.Enum):
 @enum.unique
 class EventType(str, ValuesEnumMixin, enum.Enum):
     DISCONNECT = "disconnect"
+    FACTORY_RESET = "factoryReset"
     PROVISION = "provision"
     UPDATE = "update"
     CAMERA_POWER_CYCLE = "cameraPowerCycling"
     RING = "ring"
+    DOOR_ACCESS = "doorAccess"
     RESOLUTION_LOWERED = "resolutionLowered"
     POOR_CONNECTION = "poorConnection"
     STREAM_RECOVERY = "streamRecovery"
@@ -135,21 +137,25 @@ class EventType(str, ValuesEnumMixin, enum.Enum):
     CONSOLIDATED_POOR_CONNECTION = "consolidatedPoorConnection"
     #
     INSTALLED_DISK = "installed"
+    CORRUPTED_DB_RECOVERED = "corruptedDbRecovered"
     OFFLINE = "offline"
     OFF = "off"
     REBOOT = "reboot"
     FIRMWARE_UPDATE = "fwUpdate"
     APP_UPDATE = "applicationUpdate"
+    APPLICATION_UPDATABLE = "applicationUpdatable"
     ACCESS = "access"
     DRIVE_FAILED = "driveFailed"
     CAMERA_UTILIZATION_LIMIT_REACHED = "cameraUtilizationLimitReached"
     CAMERA_UTILIZATION_LIMIT_EXCEEDED = "cameraUtilizationLimitExceeded"
+    GLOBAL_RECORDING_MODE_CHANGED = "globalRecordingModeChanged"
     #
     UNADOPTED_DEVICE_DISCOVERED = "unadoptedDeviceDiscovered"
     DEVICE_ADOPTED = "deviceAdopted"
     DEVICE_UNADOPTED = "deviceUnadopted"
     UVF_DISCOVERED = "ufvDiscovered"
     DEVICE_PASSWORD_UPDATE = "devicesPasswordUpdated"
+    DEVICE_UPDATABLE = "deviceUpdatable"
     #
     USER_LEFT = "userLeft"
     USER_ARRIVED = "userArrived"
@@ -259,6 +265,8 @@ class VideoMode(str, ValuesEnumMixin, enum.Enum):
     DEFAULT = "default"
     HIGH_FPS = "highFps"
     HOMEKIT = "homekit"
+    SPORT = "sport"
+    SLOW_SHUTTER = "slowShutter"
     # should only be for unadopted devices
     UNKNOWN = "unknown"
 
@@ -267,6 +275,7 @@ class VideoMode(str, ValuesEnumMixin, enum.Enum):
 class RecordingMode(str, ValuesEnumMixin, enum.Enum):
     ALWAYS = "always"
     NEVER = "never"
+    SCHEDULE = "schedule"
     DETECTIONS = "detections"
 
 

--- a/pyunifiprotect/data/user.py
+++ b/pyunifiprotect/data/user.py
@@ -133,6 +133,7 @@ class User(ProtectModelWithId):
     # settings
     # alertRules
     # notificationsV2
+    # notifications
 
     _groups: Optional[List[Group]] = PrivateAttr(None)
     _perm_cache: Dict[str, bool] = PrivateAttr({})

--- a/pyunifiprotect/test_util/__init__.py
+++ b/pyunifiprotect/test_util/__init__.py
@@ -135,7 +135,6 @@ class SampleDataGenerator:
             "sensor": len(bootstrap["sensors"]),
             "doorlock": len(bootstrap["doorlocks"]),
             "chime": len(bootstrap["chimes"]),
-            "schedule": len(bootstrap["schedules"]),
         }
 
         motion_event, smart_detection = await self.generate_event_data()

--- a/tests/data/test_common.py
+++ b/tests/data/test_common.py
@@ -288,7 +288,7 @@ def test_bootstrap(bootstrap: dict[str, Any]):
         del bootstrap["deviceGroups"]
     del bootstrap["legacyUFVs"]
     del bootstrap["displays"]
-    del bootstrap["schedules"]
+    bootstrap.pop("schedules", None)
     if "deviceGroups" in bootstrap:
         del bootstrap["deviceGroups"]
 


### PR DESCRIPTION
* New adopted item fields: `is_restoring`, `last_disconnect`, `anonymous_device_id` (was on many devices, but now on all)
* New camera recording settings: `in_schedule_mode` and `out_schedule_mode`
* New camera feature flags: `has_color_lcd_screen`, `has_line_crossing`, `has_line_crossing_counting`, `has_liveview_tracking`
* New Camera field: `has_recordings`
* New Chime feature flag: `has_https_client_ota`
* New NVR feature flags: `detection_labels` and `has_two_way_audio_media_streams`
* New NVR fields: `hard_drive_state`, `is_network_installed`, `is_protect_updatable`, `is_ucore_updatable`
* New events: `factoryReset`, `doorAccess`, `corruptedDbRecovered`, `applicationUpdatable`, `globalRecordingModeChanged`
* New video modes: `sport` and `slowShutter`
* New recording mode: `schedule` (rest of new API for record mods not implemented


Still todo (planned): implement method to manually trigger device updates. Need to wait for another update to be available for one of my devices.  