### PR TITLE
Add the ability to toggle Color Night Vision

### DIFF
--- a/pyunifiprotect/cli/cameras.py
+++ b/pyunifiprotect/cli/cameras.py
@@ -424,6 +424,16 @@ def set_hdr(ctx: typer.Context, enabled: bool) -> None:
 
 
 @app.command()
+def set_color_night_vision(ctx: typer.Context, enabled: bool) -> None:
+    """Sets Color Night Vision on camera"""
+
+    base.require_device_id(ctx)
+    obj: d.Camera = ctx.obj.device
+
+    base.run(ctx, obj.set_color_night_vision(enabled=enabled))
+
+
+@app.command()
 def set_video_mode(ctx: typer.Context, mode: d.VideoMode) -> None:
     """Sets video mode on camera"""
 

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -1406,7 +1406,10 @@ class Camera(ProtectMotionDeviceModel):
 
     @property
     def has_color_night_vision(self) -> bool:
-        if self.feature_flags.hotplug and self.feature_flags.hotplug.extender:
+        if self.feature_flags.hotplug is not None \
+            and self.feature_flags.hotplug.extender is not None \
+            and self.feature_flags.hotplug.extender.is_attached is not None:
+
             return self.feature_flags.hotplug.extender.is_attached
 
         return False

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -1408,8 +1408,8 @@ class Camera(ProtectMotionDeviceModel):
     def has_color_night_vision(self) -> bool:
         if self.feature_flags.hotplug and self.feature_flags.hotplug.extender:
             return self.feature_flags.hotplug.extender.is_attached
-        else:
-            return False
+
+        return False
 
     def set_ring_timeout(self) -> None:
         self._last_ring_timeout = utc_now() + EVENT_PING_INTERVAL

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -1404,6 +1404,14 @@ class Camera(ProtectMotionDeviceModel):
     def has_mic(self) -> bool:
         return self.feature_flags.has_mic or self.has_removable_speaker
 
+    @property
+    def has_color_night_vision(self) -> bool:
+        return (
+            self.feature_flags.hotplug
+            and self.feature_flags.hotplug.extender
+            and self.feature_flags.hotplug.extender.is_attached
+        )
+
     def set_ring_timeout(self) -> None:
         self._last_ring_timeout = utc_now() + EVENT_PING_INTERVAL
         self._event_callback_ping()
@@ -1574,6 +1582,17 @@ class Camera(ProtectMotionDeviceModel):
 
         def callback() -> None:
             self.hdr_mode = enabled
+
+        await self.queue_update(callback)
+
+    async def set_color_night_vision(self, enabled: bool) -> None:
+        """Sets Color Night Vision on camera"""
+
+        if not self.has_color_night_vision:
+            raise BadRequest("Camera does not have Color Night Vision")
+
+        def callback() -> None:
+            self.isp_settings.is_color_night_vision_enabled = enabled
 
         await self.queue_update(callback)
 

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -1406,10 +1406,11 @@ class Camera(ProtectMotionDeviceModel):
 
     @property
     def has_color_night_vision(self) -> bool:
-        if self.feature_flags.hotplug is not None \
-            and self.feature_flags.hotplug.extender is not None \
-            and self.feature_flags.hotplug.extender.is_attached is not None:
-
+        if (
+            self.feature_flags.hotplug is not None
+            and self.feature_flags.hotplug.extender is not None
+            and self.feature_flags.hotplug.extender.is_attached is not None
+        ):
             return self.feature_flags.hotplug.extender.is_attached
 
         return False

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -1406,11 +1406,10 @@ class Camera(ProtectMotionDeviceModel):
 
     @property
     def has_color_night_vision(self) -> bool:
-        return (
-            self.feature_flags.hotplug
-            and self.feature_flags.hotplug.extender
-            and self.feature_flags.hotplug.extender.is_attached
-        )
+        if self.feature_flags.hotplug and self.feature_flags.hotplug.extender:
+            return self.feature_flags.hotplug.extender.is_attached
+        else:
+            return False
 
     def set_ring_timeout(self) -> None:
         self._last_ring_timeout = utc_now() + EVENT_PING_INTERVAL

--- a/tests/data/test_camera.py
+++ b/tests/data/test_camera.py
@@ -188,7 +188,8 @@ async def test_camera_set_hdr(camera_obj: Optional[Camera], status: bool):
 @pytest.mark.parametrize("status", [True, False])
 @pytest.mark.asyncio()
 async def test_camera_set_color_night_vision(
-    camera_obj: Optional[Camera], status: bool,
+    camera_obj: Optional[Camera],
+    status: bool,
 ):
     if camera_obj is None:
         pytest.skip("No camera_obj obj found")

--- a/tests/data/test_camera.py
+++ b/tests/data/test_camera.py
@@ -188,7 +188,7 @@ async def test_camera_set_hdr(camera_obj: Optional[Camera], status: bool):
 @pytest.mark.parametrize("status", [True, False])
 @pytest.mark.asyncio()
 async def test_camera_set_color_night_vision(
-    camera_obj: Optional[Camera], status: bool
+    camera_obj: Optional[Camera], status: bool,
 ):
     if camera_obj is None:
         pytest.skip("No camera_obj obj found")

--- a/tests/data/test_camera.py
+++ b/tests/data/test_camera.py
@@ -16,7 +16,7 @@ from pyunifiprotect.data import (
     RecordingMode,
     VideoMode,
 )
-from pyunifiprotect.data.devices import CameraZone
+from pyunifiprotect.data.devices import CameraZone, Hotplug, HotplugExtender
 from pyunifiprotect.data.types import DEFAULT, SmartDetectObjectType
 from pyunifiprotect.data.websocket import WSAction, WSSubscriptionMessage
 from pyunifiprotect.exceptions import BadRequest
@@ -182,6 +182,48 @@ async def test_camera_set_hdr(camera_obj: Optional[Camera], status: bool):
         method="patch",
         json={"hdrMode": status},
     )
+
+
+@pytest.mark.skipif(not TEST_CAMERA_EXISTS, reason="Missing testdata")
+@pytest.mark.parametrize("status", [True, False])
+@pytest.mark.asyncio()
+async def test_camera_set_color_night_vision(
+    camera_obj: Optional[Camera], status: bool
+):
+    if camera_obj is None:
+        pytest.skip("No camera_obj obj found")
+
+    camera_obj.api.api_request.reset_mock()
+
+    camera_obj.feature_flags.hotplug = Hotplug()
+    camera_obj.feature_flags.hotplug.extender = HotplugExtender()
+    camera_obj.feature_flags.hotplug.extender.is_attached = True
+
+    camera_obj.isp_settings.is_color_night_vision_enabled = not status
+
+    await camera_obj.set_color_night_vision(status)
+
+    camera_obj.api.api_request.assert_called_with(
+        f"cameras/{camera_obj.id}",
+        method="patch",
+        json={"ispSettings": {"isColorNightVisionEnabled": status}},
+    )
+
+
+@pytest.mark.skipif(not TEST_CAMERA_EXISTS, reason="Missing testdata")
+@pytest.mark.asyncio()
+async def test_camera_set_color_night_vision_no_color_night_vision(
+    camera_obj: Optional[Camera],
+):
+    if camera_obj is None:
+        pytest.skip("No camera_obj obj found")
+
+    camera_obj.api.api_request.reset_mock()
+
+    with pytest.raises(BadRequest):
+        await camera_obj.set_color_night_vision(True)
+
+    assert not camera_obj.api.api_request.called
 
 
 @pytest.mark.skipif(not TEST_CAMERA_EXISTS, reason="Missing testdata")


### PR DESCRIPTION
Added support to control whether or not Color Night Vision is enabled.

Note: Two tests are currently failing. I tried a few things to get them passing but not sure what I'm missing. If you let me know what I need to do, I'm happy to update this PR.

This addresses: https://github.com/AngellusMortis/pyunifiprotect/issues/303

Fixes the previous PR (https://github.com/AngellusMortis/pyunifiprotect/pull/318) without a valid commit, and hoping it fixes the tests otherwise.