### PR TITLE
Updates for Protect 2.10.10

### DIFF
--- a/pyunifiprotect/cli/__init__.py
+++ b/pyunifiprotect/cli/__init__.py
@@ -12,7 +12,6 @@ from rich.progress import track
 import typer
 
 from pyunifiprotect.api import ProtectApiClient
-from pyunifiprotect.cli.backup import app as backup_app
 from pyunifiprotect.cli.base import CliContext, OutputFormatEnum
 from pyunifiprotect.cli.cameras import app as camera_app
 from pyunifiprotect.cli.chimes import app as chime_app
@@ -27,6 +26,11 @@ from pyunifiprotect.data import Version, WSPacket
 from pyunifiprotect.test_util import SampleDataGenerator
 from pyunifiprotect.utils import RELEASE_CACHE, get_local_timezone
 from pyunifiprotect.utils import profile_ws as profile_ws_job
+
+try:
+    from pyunifiprotect.cli.backup import app as backup_app
+except ImportError:
+    backup_app = None  # type: ignore[assignment]
 
 _LOGGER = logging.getLogger("pyunifiprotect")
 
@@ -123,7 +127,9 @@ app.add_typer(doorlock_app, name="doorlocks")
 app.add_typer(light_app, name="lights")
 app.add_typer(sensor_app, name="sensors")
 app.add_typer(viewer_app, name="viewers")
-app.add_typer(backup_app, name="backup")
+
+if backup_app is not None:
+    app.add_typer(backup_app, name="backup")
 
 
 @app.callback()

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -770,6 +770,9 @@ class CameraFeatureFlags(ProtectBaseObject):
     has_line_crossing: Optional[bool] = None
     has_line_crossing_counting: Optional[bool] = None
     has_liveview_tracking: Optional[bool] = None
+    # 2.10.10+
+    has_flash: Optional[bool] = None
+    is_ptz: Optional[bool] = None
 
     # TODO:
     # focus
@@ -879,6 +882,8 @@ class Camera(ProtectMotionDeviceModel):
     user_configured_ap: Optional[bool] = None
     # requires 2.9.20+
     has_recordings: Optional[bool] = None
+    # requires 2.10.10+
+    is_ptz: Optional[bool] = None
 
     # TODO: used for adopting
     # apMac read only

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -480,7 +480,7 @@ class MemoryInfo(ProtectBaseObject):
 class StorageDevice(ProtectBaseObject):
     model: str
     size: int
-    healthy: bool
+    healthy: bool | str
 
 
 class StorageInfo(ProtectBaseObject):
@@ -540,6 +540,8 @@ class UOSDisk(ProtectBaseObject):
     threshold: Optional[int] = None
     progress: Optional[PercentFloat] = None
     estimate: Optional[timedelta] = None
+    # 2.10.10+
+    size: Optional[int] = None
 
     @classmethod
     @cache
@@ -656,6 +658,9 @@ class UOSSpace(ProtectBaseObject):
 class UOSStorage(ProtectBaseObject):
     disks: list[UOSDisk]
     space: list[UOSSpace]
+
+    # TODO:
+    # sdcards
 
 
 class SystemInfo(ProtectBaseObject):

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -480,7 +480,7 @@ class MemoryInfo(ProtectBaseObject):
 class StorageDevice(ProtectBaseObject):
     model: str
     size: int
-    healthy: Union[str, bool]
+    healthy: Union[bool, str]
 
 
 class StorageInfo(ProtectBaseObject):

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -480,7 +480,7 @@ class MemoryInfo(ProtectBaseObject):
 class StorageDevice(ProtectBaseObject):
     model: str
     size: int
-    healthy: bool | str
+    healthy: Union[str, bool]
 
 
 class StorageInfo(ProtectBaseObject):

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -147,6 +147,9 @@ class EventType(str, ValuesEnumMixin, enum.Enum):
     UVF_DISCOVERED = "ufvDiscovered"
     DEVICE_PASSWORD_UPDATE = "devicesPasswordUpdated"
     DEVICE_UPDATABLE = "deviceUpdatable"
+    MULTIPLE_DEVICE_UPDATABLE = "multipleDeviceUpdatable"
+    DEVICE_DISCONNECTED = "deviceDisconnected"
+    NETWORK_DEVICE_OFFLINE = "networkDeviceOffline"
     #
     USER_LEFT = "userLeft"
     USER_ARRIVED = "userArrived"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -563,6 +563,8 @@ NEW_FIELDS = {
     "isNetworkInstalled",
     "isProtectUpdatable",
     "isUcoreUpdatable",
+    # 2.10.10+
+    "isPtz",
 }
 
 NEW_CAMERA_FEATURE_FLAGS = {
@@ -581,6 +583,9 @@ NEW_CAMERA_FEATURE_FLAGS = {
     "hasLineCrossing",
     "hasLineCrossingCounting",
     "hasLiveviewTracking",
+    # 2.10.10+
+    "hasFlash",
+    "isPtz",
 }
 
 NEW_NVR_FEATURE_FLAGS = {
@@ -742,27 +747,30 @@ def compare_objs(obj_type, expected, actual):  # noqa: PLR0915
                 expected["systemInfo"]["cpu"][key] = actual["systemInfo"]["cpu"][key]
 
         if expected["systemInfo"].get("ustorage") is not None:
-            for index, disk in enumerate(expected["systemInfo"]["ustorage"]["disks"]):
-                actual_disk = actual["systemInfo"]["ustorage"]["disks"][index]
+            actual_ustor = actual["systemInfo"]["ustorage"]
+            expected_ustor = expected["systemInfo"]["ustorage"]
+
+            expected_ustor.pop("sdcards", None)
+
+            for index, disk in enumerate(expected_ustor["disks"]):
+                actual_disk = actual_ustor["disks"][index]
                 estimate = disk.get("estimate")
                 actual_estimate = actual_disk.get("estimate")
                 if estimate is not None and actual_estimate is not None:  # noqa: SIM102
                     if math.isclose(estimate, actual_estimate, rel_tol=0.01):
-                        actual["systemInfo"]["ustorage"]["disks"][index][
-                            "estimate"
-                        ] = estimate
+                        actual_ustor["disks"][index]["estimate"] = estimate
 
-            for index, device in enumerate(expected["systemInfo"]["ustorage"]["space"]):
-                actual_device = actual["systemInfo"]["ustorage"]["space"][index]
+            for index, device in enumerate(expected_ustor["space"]):
+                actual_device = actual_ustor["space"][index]
                 estimate = device.get("estimate")
                 actual_estimate = actual_device.get("estimate")
                 if estimate is not None and actual_estimate is not None:  # noqa: SIM102
                     if math.isclose(estimate, actual_estimate, rel_tol=0.01):
-                        actual["systemInfo"]["ustorage"]["space"][index][
-                            "estimate"
-                        ] = estimate
+                        actual_ustor["space"][index]["estimate"] = estimate
                 if "space_type" not in device:
                     del actual_device["space_type"]
+                if "size" in device:
+                    actual_device["size"] = actual_device.pop("size", None)
 
         for flag in NEW_NVR_FEATURE_FLAGS:
             if flag not in expected["featureFlags"]:


### PR DESCRIPTION
Updates for UniFi Protect 2.10.10. Still need to update to UniFi OS 3.2 and test it as well. May make that a separate PR for that.


* Makes backup CLI not load if `backup` extra is not install. Fixes https://github.com/AngellusMortis/pyunifiprotect/issues/313
* Adds Camera feature flags for `has_flash` and `is_ptz` 
* Adds Camera field for `is_ptz`
* Changes `healthy` on UOS storage devices to `bool | str`
* Adds `size` field to UOS storage info
* Adds new events for `MULTIPLE_DEVICE_UPDATABLE`, `DEVICE_DISCONNECTED` and `NETWORK_DEVICE_OFFLINE`