### PR TITLE
Update reqs

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,7 @@
 #
 aiofiles==23.2.1
     # via pyunifiprotect (pyproject.toml)
-aiohttp==3.8.6
+aiohttp==3.9.1
     # via pyunifiprotect (pyproject.toml)
 aioshutil==1.3
     # via pyunifiprotect (pyproject.toml)
@@ -20,8 +20,6 @@ annotated-types==0.6.0
     #   xtyping
 asttokens==2.4.1
     # via stack-data
-async-timeout==4.0.3
-    # via aiohttp
 asyncify==0.9.2
     # via pyunifiprotect (pyproject.toml)
 attrs==23.1.0
@@ -42,16 +40,15 @@ build==1.0.3
     # via
     #   pip-tools
     #   pyunifiprotect (pyproject.toml)
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
 charset-normalizer==3.3.2
-    # via
-    #   aiohttp
-    #   requests
+    # via requests
 click==8.1.7
     # via
     #   black
     #   mkdocs
+    #   mkdocstrings
     #   pip-tools
     #   typer
 colorama==0.4.6
@@ -63,7 +60,7 @@ coverage[toml]==7.3.2
     # via
     #   pytest-cov
     #   pyunifiprotect (pyproject.toml)
-dateparser==1.1.8
+dateparser==1.2.0
     # via pyunifiprotect (pyproject.toml)
 decorator==5.1.1
     # via ipython
@@ -85,19 +82,19 @@ gitpython==3.1.40
     # via mkdocs-git-revision-date-localized-plugin
 greenlet==3.0.1
     # via sqlalchemy
-griffe==0.37.0
+griffe==0.38.0
     # via mkdocstrings-python
-idna==3.4
+idna==3.6
     # via
     #   requests
     #   yarl
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via mike
 importlib-resources==6.1.1
     # via mike
 iniconfig==2.0.0
     # via pytest
-ipython==8.17.2
+ipython==8.18.1
     # via pyunifiprotect (pyproject.toml)
 isort==5.12.0
     # via pyunifiprotect (pyproject.toml)
@@ -145,21 +142,21 @@ mkdocs-git-revision-date-localized-plugin==1.2.1
     # via pyunifiprotect (pyproject.toml)
 mkdocs-include-markdown-plugin==6.0.4
     # via pyunifiprotect (pyproject.toml)
-mkdocs-material==9.4.8
+mkdocs-material==9.4.14
     # via pyunifiprotect (pyproject.toml)
-mkdocs-material-extensions==1.3
+mkdocs-material-extensions==1.3.1
     # via mkdocs-material
-mkdocstrings[python]==0.23.0
+mkdocstrings[python]==0.24.0
     # via
     #   mkdocstrings-python
     #   pyunifiprotect (pyproject.toml)
-mkdocstrings-python==1.7.4
+mkdocstrings-python==1.7.5
     # via mkdocstrings
 multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-mypy==1.7.0
+mypy==1.7.1
     # via
     #   pyunifiprotect (pyproject.toml)
     #   sqlalchemy
@@ -185,19 +182,20 @@ pathspec==0.11.2
     # via
     #   black
     #   mkdocs
-pexpect==4.8.0
+pexpect==4.9.0
     # via ipython
 pillow==10.1.0
     # via pyunifiprotect (pyproject.toml)
 pip-tools==7.3.0
     # via pyunifiprotect (pyproject.toml)
-platformdirs==4.0.0
+platformdirs==4.1.0
     # via
     #   black
     #   mkdocs
+    #   mkdocstrings
 pluggy==1.3.0
     # via pytest
-prompt-toolkit==3.0.40
+prompt-toolkit==3.0.41
     # via ipython
 psutil==5.9.6
     # via pytest-xdist
@@ -207,20 +205,20 @@ pure-eval==0.2.2
     # via stack-data
 py-cpuinfo==9.0.0
     # via pytest-benchmark
-pydantic==2.4.2
+pydantic==2.5.2
     # via pyunifiprotect (pyproject.toml)
-pydantic-core==2.10.1
+pydantic-core==2.14.5
     # via pydantic
 pydocstyle==6.3.0
     # via pyunifiprotect (pyproject.toml)
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   ipython
     #   mkdocs-material
     #   rich
 pyjwt==2.8.0
     # via pyunifiprotect (pyproject.toml)
-pymdown-extensions==10.4
+pymdown-extensions==10.5
     # via
     #   mkdocs-material
     #   mkdocstrings
@@ -237,7 +235,7 @@ pytest==7.4.3
     #   pytest-timeout
     #   pytest-xdist
     #   pyunifiprotect (pyproject.toml)
-pytest-asyncio==0.21.1
+pytest-asyncio==0.23.2
     # via pyunifiprotect (pyproject.toml)
 pytest-benchmark==4.0.0
     # via pyunifiprotect (pyproject.toml)
@@ -247,7 +245,7 @@ pytest-sugar==0.9.7
     # via pyunifiprotect (pyproject.toml)
 pytest-timeout==2.2.0
     # via pyunifiprotect (pyproject.toml)
-pytest-xdist[psutil]==3.4.0
+pytest-xdist[psutil]==3.5.0
     # via pyunifiprotect (pyproject.toml)
 python-dateutil==2.8.2
     # via
@@ -273,9 +271,9 @@ regex==2023.10.3
     #   mkdocs-material
 requests==2.31.0
     # via mkdocs-material
-rich==13.6.0
+rich==13.7.0
     # via typer
-ruff==0.1.5
+ruff==0.1.7
     # via pyunifiprotect (pyproject.toml)
 shellingham==1.5.4
     # via typer
@@ -291,11 +289,11 @@ sqlalchemy[asyncio,mypy]==2.0.23
     # via pyunifiprotect (pyproject.toml)
 stack-data==0.6.3
     # via ipython
-termcolor==2.3.0
+termcolor==2.4.0
     # via
     #   pytest-sugar
     #   pyunifiprotect (pyproject.toml)
-traitlets==5.13.0
+traitlets==5.14.0
     # via
     #   ipython
     #   matplotlib-inline
@@ -327,7 +325,7 @@ tzdata==2023.3
     # via pyunifiprotect (pyproject.toml)
 tzlocal==5.2
     # via dateparser
-urllib3==2.0.7
+urllib3==2.1.0
     # via requests
 verspec==0.1.0
     # via mike
@@ -335,13 +333,13 @@ watchdog==3.0.0
     # via mkdocs
 wcmatch==8.5
     # via mkdocs-include-markdown-plugin
-wcwidth==0.2.9
+wcwidth==0.2.12
     # via prompt-toolkit
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
 xtyping==0.7.0
     # via asyncify
-yarl==1.9.2
+yarl==1.9.3
     # via aiohttp
 zipp==3.17.0
     # via importlib-metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,10 @@ ignore_missing_imports = true
 module = "av.*"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "async_timeout.*"
+ignore_missing_imports = true
+
 ## test metadata
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ max-complexity = 10
     "PLC0415",
     "PLR0911",
     "PLR0912",
+    "PLR0917",
     "PLR2004",
     "PTH",
     "SLF001",

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -326,7 +326,7 @@ class ProtectBaseObject(BaseModel):
         """
 
         # get the API client instance
-        api = cls._get_api(data.get("api", None))
+        api = cls._get_api(data.get("api"))
 
         # remap keys that will not be converted correctly by snake_case convert
         remaps = cls._get_unifi_remaps()

--- a/pyunifiprotect/websocket.py
+++ b/pyunifiprotect/websocket.py
@@ -94,7 +94,7 @@ class Websocket:
         try:
             self._ws_connection = await session.ws_connect(
                 self.url,
-                ssl=self.verify,
+                ssl=None if self.verify else False,
                 headers=self._headers,
             )
             start_event.set()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 aiofiles==23.2.1
     # via pyunifiprotect (pyproject.toml)
-aiohttp==3.8.6
+aiohttp==3.9.1
     # via pyunifiprotect (pyproject.toml)
 aioshutil==1.3
     # via pyunifiprotect (pyproject.toml)
@@ -20,21 +20,17 @@ annotated-types==0.6.0
     #   xtyping
 asttokens==2.4.1
     # via stack-data
-async-timeout==4.0.3
-    # via aiohttp
 asyncify==0.9.2
     # via pyunifiprotect (pyproject.toml)
 attrs==23.1.0
     # via aiohttp
 av==11.0.0
     # via pyunifiprotect (pyproject.toml)
-charset-normalizer==3.3.2
-    # via aiohttp
 click==8.1.7
     # via typer
 colorama==0.4.6
     # via typer
-dateparser==1.1.8
+dateparser==1.2.0
     # via pyunifiprotect (pyproject.toml)
 decorator==5.1.1
     # via ipython
@@ -48,9 +44,9 @@ funkify==0.4.5
     # via asyncify
 greenlet==3.0.1
     # via sqlalchemy
-idna==3.4
+idna==3.6
     # via yarl
-ipython==8.17.2
+ipython==8.18.1
     # via pyunifiprotect (pyproject.toml)
 jedi==0.19.1
     # via ipython
@@ -70,21 +66,21 @@ packaging==23.2
     # via pyunifiprotect (pyproject.toml)
 parso==0.8.3
     # via jedi
-pexpect==4.8.0
+pexpect==4.9.0
     # via ipython
 pillow==10.1.0
     # via pyunifiprotect (pyproject.toml)
-prompt-toolkit==3.0.40
+prompt-toolkit==3.0.41
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pydantic==2.4.2
+pydantic==2.5.2
     # via pyunifiprotect (pyproject.toml)
-pydantic-core==2.10.1
+pydantic-core==2.14.5
     # via pydantic
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   ipython
     #   rich
@@ -98,7 +94,7 @@ pytz==2023.3.post1
     # via dateparser
 regex==2023.10.3
     # via dateparser
-rich==13.6.0
+rich==13.7.0
     # via typer
 shellingham==1.5.4
     # via typer
@@ -110,9 +106,9 @@ sqlalchemy[asyncio]==2.0.23
     # via pyunifiprotect (pyproject.toml)
 stack-data==0.6.3
     # via ipython
-termcolor==2.3.0
+termcolor==2.4.0
     # via pyunifiprotect (pyproject.toml)
-traitlets==5.13.0
+traitlets==5.14.0
     # via
     #   ipython
     #   matplotlib-inline
@@ -129,9 +125,9 @@ typing-extensions==4.8.0
     #   xtyping
 tzlocal==5.2
     # via dateparser
-wcwidth==0.2.9
+wcwidth==0.2.12
     # via prompt-toolkit
 xtyping==0.7.0
     # via asyncify
-yarl==1.9.2
+yarl==1.9.3
     # via aiohttp


### PR DESCRIPTION
Just a bump of the pinned requirements. Also, one fix for aiohttp since it does not accept a `True` anymore for the `ssl` param.