### PR TITLE
Fixes broken UUID from Protect

### DIFF
--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -81,6 +81,7 @@ _LOGGER = logging.getLogger(__name__)
 RELEASE_CACHE = Path(__file__).parent / "release_cache.json"
 
 _CREATE_TYPES = {IPv6Address, IPv4Address, UUID, Color, Decimal, Path, Version}
+_BAD_UUID = "00000000-0000-00 0- 000-000000000000"
 
 IP_TYPES = {
     Union[IPv4Address, str, None],
@@ -230,6 +231,10 @@ def convert_unifi_data(value: Any, field: ModelField) -> Any:
         if type_ == datetime:
             return from_js_time(value)
         if type_ in _CREATE_TYPES or (isclass(type_) and issubclass(type_, Enum)):
+            # handle edge case for improperly formated UUIDs
+            # 00000000-0000-00 0- 000-000000000000
+            if type_ == UUID and value == _BAD_UUID:
+                value = "0" * 32
             return type_(value)
 
     return value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ from pyunifiprotect import ProtectApiClient
 from pyunifiprotect.data import Camera, ModelType
 from pyunifiprotect.data.nvr import Event
 from pyunifiprotect.data.types import EventType
-from pyunifiprotect.utils import set_debug, set_no_debug
+from pyunifiprotect.utils import _BAD_UUID, set_debug, set_no_debug
 from tests.sample_data.constants import CONSTANTS
 
 UFP_SAMPLE_DIR = os.environ.get("UFP_SAMPLE_DIR")
@@ -808,6 +808,14 @@ def compare_objs(obj_type, expected, actual):  # noqa: PLR0915
     if "hardwareRevision" in expected and expected["hardwareRevision"] is not None:
         expected["hardwareRevision"] = str(expected["hardwareRevision"])
         actual["hardwareRevision"] = str(actual["hardwareRevision"])
+
+    # edge case with broken UUID from Protect
+    if (
+        "guid" in expected
+        and expected["guid"] == _BAD_UUID
+        and actual["guid"] == "00000000-0000-0000-0000-000000000000"
+    ):
+        actual["guid"] = expected["guid"]
 
     for key in NEW_FIELDS.intersection(actual.keys()):
         if key not in expected:

--- a/tests/sample_data/sample_camera.json
+++ b/tests/sample_data/sample_camera.json
@@ -574,5 +574,6 @@
     "canManage": false,
     "isManaged": true,
     "marketName": "G4 Doorbell Pro",
-    "modelKey": "camera"
+    "modelKey": "camera",
+    "guid": "00000000-0000-00 0- 000-000000000000"
 }


### PR DESCRIPTION
Protect is emitting an invalidly formatted UUID that is causing Python's native UUID type to throw an exception. This should handle the edge case.