### PR TITLE
Clear cookies upon reauthenticate

### DIFF
--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -413,6 +413,9 @@ class BaseApiClient:
             if self._session is not None:
                 self._session.cookie_jar.clear()
 
+                if self.headers is not None and "cookie" in self.headers:
+                    del self.headers["cookie"]
+
             auth = {
                 "username": self._username,
                 "password": self._password,


### PR DESCRIPTION
I have the issue as reported in #320 and upon some digging I noticed that the call to /login returned a 401 error after 2 hours as the old expired token was sent together with the credentials.
A retry mechanism ensures the login is done again and this works so there's no real interruption but still throws an exception.

The cookie jar is cleared for the /login call but the expired cookie needs to be removed from the HTTP headers too for this to work.

After the code change the logs stay clean and no more exceptions are logged related to the login. 

I created a new PR for a clean integration with signed commits and black/ruff checked. 