### PR TITLE
Automatically set enums to unknown for ones that support it

### DIFF
--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -65,7 +65,8 @@ class ValuesEnumMixin:
 class UnknownValuesEnumMixin(ValuesEnumMixin):
     @classmethod
     def _missing_(cls, value: Any) -> Optional[Any]:
-        return super()._missing_(value) or cls._values_normalized.get("unknown")
+        # value always set in superclass _missing
+        return super()._missing_(value) or cls._values_normalized.get("unknown")  # type: ignore[union-attr]
 
 
 @enum.unique

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -62,6 +62,12 @@ class ValuesEnumMixin:
         return cls._values_normalized.get(value_normal)
 
 
+class UnknownValuesEnumMixin(ValuesEnumMixin):
+    @classmethod
+    def _missing_(cls, value: Any) -> Optional[Any]:
+        return super()._missing_(value) or cls._values_normalized.get("unknown")
+
+
 @enum.unique
 class ModelType(str, ValuesEnumMixin, enum.Enum):
     CAMERA = "camera"
@@ -259,7 +265,7 @@ class LightModeType(str, ValuesEnumMixin, enum.Enum):
 
 
 @enum.unique
-class VideoMode(str, ValuesEnumMixin, enum.Enum):
+class VideoMode(str, UnknownValuesEnumMixin, enum.Enum):
     DEFAULT = "default"
     HIGH_FPS = "highFps"
     HOMEKIT = "homekit"
@@ -324,7 +330,7 @@ class SensorType(str, ValuesEnumMixin, enum.Enum):
 
 
 @enum.unique
-class SensorStatusType(str, ValuesEnumMixin, enum.Enum):
+class SensorStatusType(str, UnknownValuesEnumMixin, enum.Enum):
     OFFLINE = "offline"
     UNKNOWN = "unknown"
     SAFE = "safe"
@@ -393,7 +399,7 @@ class LowMedHigh(str, ValuesEnumMixin, enum.Enum):
 
 
 @enum.unique
-class StorageType(str, ValuesEnumMixin, enum.Enum):
+class StorageType(str, UnknownValuesEnumMixin, enum.Enum):
     DISK = "hdd"
     RAID = "raid"
     SD_CARD = "sdcard"

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -266,7 +266,7 @@ class LightModeType(str, ValuesEnumMixin, enum.Enum):
 
 
 @enum.unique
-class VideoMode(str, UnknownValuesEnumMixin, enum.Enum):
+class VideoMode(str, ValuesEnumMixin, enum.Enum):
     DEFAULT = "default"
     HIGH_FPS = "highFps"
     HOMEKIT = "homekit"


### PR DESCRIPTION
To better guard against unknown values from protect, any enum that already has an "unknown" value will have their value set to unknown if an unlisted value is passed in. 