### PR TITLE
Make bootstrap_models a tuple

### DIFF
--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -101,12 +101,12 @@ class ModelType(str, ValuesEnumMixin, enum.Enum):
     RECORDING_SCHEDULE = "recordingSchedule"
 
     @staticmethod
-    def bootstrap_models() -> list[str]:
+    def bootstrap_models() -> tuple[str, ...]:
         # TODO:
         # legacyUFV
         # display
 
-        return [
+        return (
             ModelType.CAMERA.value,
             ModelType.USER.value,
             ModelType.GROUP.value,
@@ -117,7 +117,7 @@ class ModelType(str, ValuesEnumMixin, enum.Enum):
             ModelType.SENSOR.value,
             ModelType.DOORLOCK.value,
             ModelType.CHIME.value,
-        ]
+        )
 
 
 @enum.unique

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
 import enum
-from typing import Any, Literal, Optional, TypeVar, Union
+from typing import Any, Literal, Optional, Tuple, TypeVar, Union
 
 from packaging.version import Version as BaseVersion
 
@@ -101,7 +101,7 @@ class ModelType(str, ValuesEnumMixin, enum.Enum):
     RECORDING_SCHEDULE = "recordingSchedule"
 
     @staticmethod
-    def bootstrap_models() -> tuple[str, ...]:
+    def bootstrap_models() -> Tuple[str, ...]:
         # TODO:
         # legacyUFV
         # display

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
 import enum
-from typing import Any, Literal, Optional, Tuple, TypeVar, Union
+from typing import Any, Literal, Optional, TypeVar, Union
 
 from packaging.version import Version as BaseVersion
 
@@ -101,7 +101,7 @@ class ModelType(str, ValuesEnumMixin, enum.Enum):
     RECORDING_SCHEDULE = "recordingSchedule"
 
     @staticmethod
-    def bootstrap_models() -> Tuple[str, ...]:
+    def bootstrap_models() -> tuple[str, ...]:
         # TODO:
         # legacyUFV
         # display


### PR DESCRIPTION
tuples are stored as constants in the code object so they do not get recreated every time this function is called. It would have been faster to decorate it with `@cached_property` and make it a property except `@cache_property` has an undocumented class instance lock which would have made it not viable until they fixed it in py 3.12 (maybe not a problem in this instance, but I wanted to go for a simple change here)