### PR TITLE
Updates for Protect 2.11.13

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -93,24 +93,25 @@
                 "python.linting.enabled": true,
                 // python linting
                 "black.args": [
-                    "--config=/opt/app/pyproject.toml"
+                    "--config=/workspaces/pyunifiprotect/pyproject.toml"
                 ],
                 "isort.args": [
-                    "--settings-path=/opt/app/pyproject.toml"
+                    "--settings-path=/workspaces/pyunifiprotect/pyproject.toml"
                 ],
                 // "mypy-type-checker.importStrategy": "fromEnvironment",
                 "mypy-type-checker.interpreter": [
                     "/usr/local/bin/python"
                 ],
                 "mypy-type-checker.args": [
-                    "--config-file=/opt/app/pyproject.toml"
+                    "--config-file=/workspaces/pyunifiprotect/pyproject.toml"
                 ],
                 "mypy-type-checker.severity": {
                     "error": "Error",
                     "note": "Warning"
                 },
                 "ruff.lint.args": [
-                    "--preview --config=/opt/app/pyproject.toml"
+                    "--preview",
+                    "--config=/workspaces/pyunifiprotect/pyproject.toml"
                 ],
                 "ruff.fixAll": true,
                 "ruff.organizeImports": false,

--- a/pyunifiprotect/data/__init__.py
+++ b/pyunifiprotect/data/__init__.py
@@ -33,6 +33,7 @@ from pyunifiprotect.data.types import (
     DEFAULT,
     DEFAULT_TYPE,
     AnalyticsOption,
+    AudioStyle,
     ChimeType,
     Color,
     CoordType,
@@ -75,6 +76,7 @@ from pyunifiprotect.data.websocket import (
 
 __all__ = [
     "AnalyticsOption",
+    "AudioStyle",
     "Bootstrap",
     "Bridge",
     "Camera",

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -62,6 +62,8 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 MAX_SUPPORTED_CAMERAS = 256
 MAX_EVENT_HISTORY_IN_STATE_MACHINE = MAX_SUPPORTED_CAMERAS * 2
+DELETE_KEYS_THUMB = {"color", "vehicleType"}
+DELETE_KEYS_EVENT = {"deletedAt", "category", "subCategory"}
 
 
 class NVRLocation(UserLocation):
@@ -140,8 +142,7 @@ class EventThumbnailAttributes(ProtectBaseObject):
     ) -> dict[str, Any]:
         data = super().unifi_dict(data=data, exclude=exclude)
 
-        delete_keys = {"color", "vehicleType"}
-        for key in delete_keys.intersection(data.keys()):
+        for key in DELETE_KEYS_THUMB.intersection(data.keys()):
             if data[key] is None:
                 del data[key]
 
@@ -293,8 +294,7 @@ class Event(ProtectModelWithId):
     ) -> dict[str, Any]:
         data = super().unifi_dict(data=data, exclude=exclude)
 
-        delete_keys = {"deletedAt", "category", "subCategory"}
-        for key in delete_keys.intersection(data.keys()):
+        for key in DELETE_KEYS_EVENT.intersection(data.keys()):
             if data[key] is None:
                 del data[key]
 

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -124,6 +124,44 @@ class LicensePlateMetadata(ProtectBaseObject):
     confidence_level: int
 
 
+class EventThumbnailAttribute(ProtectBaseObject):
+    confidence: int
+    val: str
+
+
+class EventThumbnailAttributes(ProtectBaseObject):
+    color: Optional[EventThumbnailAttribute] = None
+    vehicle_type: Optional[EventThumbnailAttribute] = None
+
+    def unifi_dict(
+        self,
+        data: Optional[dict[str, Any]] = None,
+        exclude: Optional[set[str]] = None,
+    ) -> dict[str, Any]:
+        data = super().unifi_dict(data=data, exclude=exclude)
+
+        delete_keys = {"color", "vehicleType"}
+        for key in delete_keys.intersection(data.keys()):
+            if data[key] is None:
+                del data[key]
+
+        return data
+
+
+class EventDetectedThumbnail(ProtectBaseObject):
+    clock_best_wall: datetime
+    type: str
+    cropped_id: str
+    attributes: Optional[EventThumbnailAttributes] = None
+
+    @classmethod
+    def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
+        if "clockBestWall" in data:
+            data["clockBestWall"] = process_datetime(data, "clockBestWall")
+
+        return super().unifi_dict_to_dict(data)
+
+
 class EventMetadata(ProtectBaseObject):
     client_platform: Optional[str]
     reason: Optional[str]
@@ -145,6 +183,8 @@ class EventMetadata(ProtectBaseObject):
     mac: Optional[str]
     # require 2.7.5+
     license_plate: Optional[LicensePlateMetadata] = None
+    # requires 2.11.13+
+    detected_thumbnails: Optional[list[EventDetectedThumbnail]] = None
 
     _collapse_keys: ClassVar[SetStr] = {
         "lightId",
@@ -253,15 +293,10 @@ class Event(ProtectModelWithId):
     ) -> dict[str, Any]:
         data = super().unifi_dict(data=data, exclude=exclude)
 
-        if "deletedAt" in data and data["deletedAt"] is None:
-            del data["deletedAt"]
-
-        # category/subCategory optionally added
-        if "category" in data and data["category"] is None:
-            del data["category"]
-
-        if "subCategory" in data and data["subCategory"] is None:
-            del data["subCategory"]
+        delete_keys = {"deletedAt", "category", "subCategory"}
+        for key in delete_keys.intersection(data.keys()):
+            if data[key] is None:
+                del data[key]
 
         return data
 
@@ -896,6 +931,8 @@ class NVR(ProtectDeviceModel):
     is_network_installed: Optional[bool] = None
     is_protect_updatable: Optional[bool] = None
     is_ucore_updatable: Optional[bool] = None
+    # requires 2.11.13+
+    last_device_fw_updates_checked_at: Optional[datetime] = None
 
     # TODO:
     # errorCode   read only
@@ -914,6 +951,7 @@ class NVR(ProtectDeviceModel):
             **super()._get_unifi_remaps(),
             "recordingRetentionDurationMs": "recordingRetentionDuration",
             "vaultCameras": "vaultCameraIds",
+            "lastDeviceFWUpdatesCheckedAt": "lastDeviceFwUpdatesCheckedAt",
         }
 
     @classmethod
@@ -942,6 +980,11 @@ class NVR(ProtectDeviceModel):
     def unifi_dict_to_dict(cls, data: dict[str, Any]) -> dict[str, Any]:
         if "lastUpdateAt" in data:
             data["lastUpdateAt"] = process_datetime(data, "lastUpdateAt")
+        if "lastDeviceFwUpdatesCheckedAt" in data:
+            data["lastDeviceFwUpdatesCheckedAt"] = process_datetime(
+                data,
+                "lastDeviceFwUpdatesCheckedAt",
+            )
         if (
             "recordingRetentionDurationMs" in data
             and data["recordingRetentionDurationMs"] is not None

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -142,6 +142,9 @@ class EventType(str, ValuesEnumMixin, enum.Enum):
     HOTPLUG = "hotplug"
     CONSOLIDATED_RESOLUTION_LOWERED = "consolidatedResolutionLowered"
     CONSOLIDATED_POOR_CONNECTION = "consolidatedPoorConnection"
+    CAMERA_CONNECTED = "cameraConnected"
+    CAMERA_REBOOTED = "cameraRebooted"
+    CAMERA_DISCONNECTED = "cameraDisconnected"
     #
     INSTALLED_DISK = "installed"
     CORRUPTED_DB_RECOVERED = "corruptedDbRecovered"
@@ -155,15 +158,20 @@ class EventType(str, ValuesEnumMixin, enum.Enum):
     DRIVE_FAILED = "driveFailed"
     CAMERA_UTILIZATION_LIMIT_REACHED = "cameraUtilizationLimitReached"
     CAMERA_UTILIZATION_LIMIT_EXCEEDED = "cameraUtilizationLimitExceeded"
+    DRIVE_SLOW = "driveSlow"
     GLOBAL_RECORDING_MODE_CHANGED = "globalRecordingModeChanged"
+    NVR_SETTINGS_CHANGED = "nvrSettingsChanged"
     #
     UNADOPTED_DEVICE_DISCOVERED = "unadoptedDeviceDiscovered"
+    MULTIPLE_UNADOPTED_DEVICE_DISCOVERED = "multipleUnadoptedDeviceDiscovered"
     DEVICE_ADOPTED = "deviceAdopted"
     DEVICE_UNADOPTED = "deviceUnadopted"
     UVF_DISCOVERED = "ufvDiscovered"
     DEVICE_PASSWORD_UPDATE = "devicesPasswordUpdated"
     DEVICE_UPDATABLE = "deviceUpdatable"
     MULTIPLE_DEVICE_UPDATABLE = "multipleDeviceUpdatable"
+    DEVICE_CONNECTED = "deviceConnected"
+    DEVICE_REBOOTED = "deviceRebooted"
     DEVICE_DISCONNECTED = "deviceDisconnected"
     NETWORK_DEVICE_OFFLINE = "networkDeviceOffline"
     #
@@ -232,17 +240,19 @@ class SmartDetectObjectType(str, ValuesEnumMixin, enum.Enum):
     PACKAGE = "package"
     # old?
     CAR = "car"
-    # actually audioType?
     SMOKE = "alrmSmoke"
     CMONX = "alrmCmonx"
+    SIREN = "alrmSiren"
+    BABY_CRY = "alrmBabyCry"
+    SPEAK = "alrmSpeak"
+    BARK = "alrmBark"
+    BURGLAR = "alrmBurglar"
+    CAR_HORN = "alrmCarHorn"
+    GLASS_BREAK = "alrmGlassBreak"
 
     @property
     def audio_type(self) -> Optional[SmartDetectAudioType]:
-        if self == SmartDetectObjectType.SMOKE:
-            return SmartDetectAudioType.SMOKE
-        if self == SmartDetectObjectType.CMONX:
-            return SmartDetectAudioType.CMONX
-        return None
+        return OBJECT_TO_AUDIO_MAP.get(self)
 
 
 @enum.unique
@@ -250,6 +260,41 @@ class SmartDetectAudioType(str, ValuesEnumMixin, enum.Enum):
     SMOKE = "alrmSmoke"
     CMONX = "alrmCmonx"
     SMOKE_CMONX = "smoke_cmonx"
+    SIREN = "alrmSiren"
+    BABY_CRY = "alrmBabyCry"
+    SPEAK = "alrmSpeak"
+    BARK = "alrmBark"
+    BURGLAR = "alrmBurglar"
+    CAR_HORN = "alrmCarHorn"
+    GLASS_BREAK = "alrmGlassBreak"
+
+
+@enum.unique
+class DetectionColor(str, ValuesEnumMixin, enum.Enum):
+    BLACK = "black"
+    BLUE = "blue"
+    BROWN = "brown"
+    GRAY = "gray"
+    GREEN = "green"
+    ORANGE = "orange"
+    PINK = "pink"
+    PURPLE = "purple"
+    RED = "red"
+    WHITE = "white"
+    YELLOW = "yellow"
+
+
+OBJECT_TO_AUDIO_MAP = {
+    SmartDetectObjectType.SMOKE: SmartDetectAudioType.SMOKE,
+    SmartDetectObjectType.CMONX: SmartDetectAudioType.CMONX,
+    SmartDetectObjectType.SIREN: SmartDetectAudioType.SIREN,
+    SmartDetectObjectType.BABY_CRY: SmartDetectAudioType.BABY_CRY,
+    SmartDetectObjectType.SPEAK: SmartDetectAudioType.SPEAK,
+    SmartDetectObjectType.BARK: SmartDetectAudioType.BARK,
+    SmartDetectObjectType.BURGLAR: SmartDetectAudioType.BURGLAR,
+    SmartDetectObjectType.CAR_HORN: SmartDetectAudioType.CAR_HORN,
+    SmartDetectObjectType.GLASS_BREAK: SmartDetectAudioType.GLASS_BREAK,
+}
 
 
 @enum.unique
@@ -283,6 +328,12 @@ class VideoMode(str, ValuesEnumMixin, enum.Enum):
     SLOW_SHUTTER = "slowShutter"
     # should only be for unadopted devices
     UNKNOWN = "unknown"
+
+
+@enum.unique
+class AudioStyle(str, UnknownValuesEnumMixin, enum.Enum):
+    NATURE = "nature"
+    NOISE_REDUCED = "noiseReduced"
 
 
 @enum.unique


### PR DESCRIPTION
Just a first pass because I have to expose all of these on objects as well. 

Updates for UniFi Protect 2.11.13:
* Adds `retention_duration`, `smart_detect_post_padding`, `smart_detect_pre_padding` recording settings for cameras
* Adds `audio_style` and `has_vertical_flip` feature flags for cameras
* Adds `audio_settings` for cameras
* Adds `detected_thumbnails` support for Events
* Adds `last_device_fw_updates_checked_at` for NVR
* Adds new event and smart detection enums (will be exposed on camera objects in follow up)