### PR TITLE
add ptz auto tracking

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -118,6 +118,7 @@ unifi-protect cameras DEVICE_ID COMMAND
 | Command    | Description          |
 | ---------- | -------------------- |
 | `list-ids` | Requires no device ID. Prints list of "id name" for each device. |
+| `set-person-track` | Requires device ID. Sets person auto tracking on or off for PTZ cameras. |
 
 ##### Examples
 

--- a/pyunifiprotect/cli/cameras.py
+++ b/pyunifiprotect/cli/cameras.py
@@ -442,10 +442,12 @@ def set_auto_track(ctx: typer.Context, enabled: bool) -> None:
 
     base.require_device_id(ctx)
     obj: d.Camera = ctx.obj.device
+    
+    if not obj.feature_flags.is_ptz:
+        typer.secho("Camera does not support auto tracking", fg="red")
+        raise typer.Exit(1)
 
-    data_before_changes = obj.dict_with_excludes()
-    obj.smart_detect_settings.auto_tracking_object_types = [d.SmartDetectObjectType.PERSON] if enabled else []
-    base.run(ctx, obj.save_device(data_before_changes))
+    base.run(ctx, (obj.set_auto_track(enabled=enabled)))
 
 @app.command()
 def set_video_mode(ctx: typer.Context, mode: d.VideoMode) -> None:

--- a/pyunifiprotect/cli/cameras.py
+++ b/pyunifiprotect/cli/cameras.py
@@ -437,17 +437,17 @@ def set_color_night_vision(ctx: typer.Context, enabled: bool) -> None:
     base.run(ctx, obj.set_color_night_vision(enabled=enabled))
 
 @app.command()
-def set_auto_track(ctx: typer.Context, enabled: bool) -> None:
-    """Sets Auto Track on camera"""
+def set_person_track(ctx: typer.Context, enabled: bool) -> None:
+    """Sets person tracking on camera"""
 
     base.require_device_id(ctx)
     obj: d.Camera = ctx.obj.device
     
     if not obj.feature_flags.is_ptz:
-        typer.secho("Camera does not support auto tracking", fg="red")
+        typer.secho("Camera does not support person tracking", fg="red")
         raise typer.Exit(1)
 
-    base.run(ctx, (obj.set_auto_track(enabled=enabled)))
+    base.run(ctx, (obj.set_person_track(enabled=enabled)))
 
 @app.command()
 def set_video_mode(ctx: typer.Context, mode: d.VideoMode) -> None:

--- a/pyunifiprotect/cli/cameras.py
+++ b/pyunifiprotect/cli/cameras.py
@@ -436,6 +436,16 @@ def set_color_night_vision(ctx: typer.Context, enabled: bool) -> None:
 
     base.run(ctx, obj.set_color_night_vision(enabled=enabled))
 
+@app.command()
+def set_auto_track(ctx: typer.Context, enabled: bool) -> None:
+    """Sets Auto Track on camera"""
+
+    base.require_device_id(ctx)
+    obj: d.Camera = ctx.obj.device
+
+    data_before_changes = obj.dict_with_excludes()
+    obj.smart_detect_settings.auto_tracking_object_types = [d.SmartDetectObjectType.PERSON] if enabled else []
+    base.run(ctx, obj.save_device(data_before_changes))
 
 @app.command()
 def set_video_mode(ctx: typer.Context, mode: d.VideoMode) -> None:

--- a/pyunifiprotect/cli/cameras.py
+++ b/pyunifiprotect/cli/cameras.py
@@ -436,18 +436,20 @@ def set_color_night_vision(ctx: typer.Context, enabled: bool) -> None:
 
     base.run(ctx, obj.set_color_night_vision(enabled=enabled))
 
+
 @app.command()
 def set_person_track(ctx: typer.Context, enabled: bool) -> None:
     """Sets person tracking on camera"""
 
     base.require_device_id(ctx)
     obj: d.Camera = ctx.obj.device
-    
+
     if not obj.feature_flags.is_ptz:
         typer.secho("Camera does not support person tracking", fg="red")
         raise typer.Exit(1)
 
     base.run(ctx, (obj.set_person_track(enabled=enabled)))
+
 
 @app.command()
 def set_video_mode(ctx: typer.Context, mode: d.VideoMode) -> None:

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -2244,14 +2244,13 @@ class Camera(ProtectMotionDeviceModel):
 
         await self.queue_update(callback)
         
-    async def set_auto_track(self, enabled: bool) -> None:
-        """Sets auto tracking on camera"""
+    async def set_person_track(self, enabled: bool) -> None:
+        """Sets person tracking on camera"""
 
         if not self.feature_flags.is_ptz:
-            raise BadRequest("Camera does not support auto tracking")
+            raise BadRequest("Camera does not support person tracking")
         
         def callback() -> None:
-            data_before_changes = self.dict_with_excludes()
             self.smart_detect_settings.auto_tracking_object_types = [SmartDetectObjectType.PERSON] if enabled else []
         
         await self.queue_update(callback)

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -2243,6 +2243,18 @@ class Camera(ProtectMotionDeviceModel):
                 self.recording_settings.mode = recording_mode
 
         await self.queue_update(callback)
+        
+    async def set_auto_track(self, enabled: bool) -> None:
+        """Sets auto tracking on camera"""
+
+        if not self.feature_flags.is_ptz:
+            raise BadRequest("Camera does not support auto tracking")
+        
+        def callback() -> None:
+            data_before_changes = self.dict_with_excludes()
+            self.smart_detect_settings.auto_tracking_object_types = [SmartDetectObjectType.PERSON] if enabled else []
+        
+        await self.queue_update(callback)
 
     def create_talkback_stream(
         self,

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -452,6 +452,10 @@ class SmartDetectSettings(ProtectBaseObject):
             data["objectTypes"] = convert_smart_types(data.pop("objectTypes"))
         if "audioTypes" in data:
             data["audioTypes"] = convert_smart_audio_types(data.pop("audioTypes"))
+        if "autoTrackingObjectTypes" in data:
+            data["autoTrackingObjectTypes"] = convert_smart_types(
+                data.pop("autoTrackingObjectTypes"),
+            )
 
         return super().unifi_dict_to_dict(data)
 
@@ -1207,6 +1211,13 @@ class Camera(ProtectMotionDeviceModel):
         """Toggles person smart detection. Requires camera to have smart detection"""
 
         return await self._set_object_detect(SmartDetectObjectType.PERSON, enabled)
+    
+    @property
+    def is_auto_tracking_on(self) -> bool:
+        return (
+            self.is_recording_enabled
+            and SmartDetectObjectType.PERSON in self.smart_detect_settings.auto_tracking_object_types
+        )
 
     # vehicle
 

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -1211,12 +1211,15 @@ class Camera(ProtectMotionDeviceModel):
         """Toggles person smart detection. Requires camera to have smart detection"""
 
         return await self._set_object_detect(SmartDetectObjectType.PERSON, enabled)
-    
+
     @property
-    def is_auto_tracking_on(self) -> bool:
+    def is_person_tracking_enabled(self) -> bool:
+        """Is person tracking enabled"""
         return (
             self.is_recording_enabled
-            and SmartDetectObjectType.PERSON in self.smart_detect_settings.auto_tracking_object_types
+            and self.smart_detect_settings.auto_tracking_object_types is not None
+            and SmartDetectObjectType.PERSON
+            in self.smart_detect_settings.auto_tracking_object_types
         )
 
     # vehicle
@@ -2243,16 +2246,18 @@ class Camera(ProtectMotionDeviceModel):
                 self.recording_settings.mode = recording_mode
 
         await self.queue_update(callback)
-        
+
     async def set_person_track(self, enabled: bool) -> None:
         """Sets person tracking on camera"""
 
         if not self.feature_flags.is_ptz:
             raise BadRequest("Camera does not support person tracking")
-        
+
         def callback() -> None:
-            self.smart_detect_settings.auto_tracking_object_types = [SmartDetectObjectType.PERSON] if enabled else []
-        
+            self.smart_detect_settings.auto_tracking_object_types = (
+                [SmartDetectObjectType.PERSON] if enabled else []
+            )
+
         await self.queue_update(callback)
 
     def create_talkback_stream(


### PR DESCRIPTION
The HTTP request for turning PTZ Auto Tracking simply modifies the smart detect settings of the cam.

For turning on:
  "body": "{\"smartDetectSettings\":{\"autoTrackingObjectTypes\":[\"person\"]}}",
  "method": "PATCH",

For turning off:
  "body": "{\"smartDetectSettings\":{\"autoTrackingObjectTypes\":[]}}",
  "method": "PATCH",

I dont know why its done like this, maybe they plan on enabling auto tracking on other objects than persons in the future. 
Ive added the simple functionallity to control auto track with the cli.