### PR TITLE
Use URL objects for aiohttp requests

### DIFF
--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -260,7 +260,7 @@ class BaseApiClient:
         for attempt in range(2):
             try:
                 req_context = session.request(
-                    method, request_url, headers=headers, **kwargs
+                    method, request_url, headers=headers, **kwargs,
                 )
                 response = await req_context.__aenter__()
 

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -259,7 +259,9 @@ class BaseApiClient:
 
         for attempt in range(2):
             try:
-                req_context = session.request(method, request_url, headers=headers, **kwargs)
+                req_context = session.request(
+                    method, request_url, headers=headers, **kwargs
+                )
                 response = await req_context.__aenter__()
 
                 self._update_last_token_cookie(response)

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -177,6 +177,10 @@ class BaseApiClient:
         if session is not None:
             self._session = session
 
+        self._update_url()
+
+    def _update_url(self) -> None:
+        """Updates the url after changing _host or _port."""
         if self._port != 443:
             self._url = URL(f"https://{self._host}:{self._port}")
         else:

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -260,7 +260,10 @@ class BaseApiClient:
         for attempt in range(2):
             try:
                 req_context = session.request(
-                    method, request_url, headers=headers, **kwargs,
+                    method,
+                    request_url,
+                    headers=headers,
+                    **kwargs,
                 )
                 response = await req_context.__aenter__()
 

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -250,16 +250,16 @@ class BaseApiClient:
         if require_auth:
             await self.ensure_authenticated()
 
-        url = self._url.joinpath(url)
+        request_url = self._url.joinpath(url)
         headers = kwargs.get("headers") or self.headers
-        _LOGGER.debug("Request url: %s", url)
+        _LOGGER.debug("Request url: %s", request_url)
         if not self._verify_ssl:
             kwargs["ssl"] = False
         session = await self.get_session()
 
         for attempt in range(2):
             try:
-                req_context = session.request(method, url, headers=headers, **kwargs)
+                req_context = session.request(method, request_url, headers=headers, **kwargs)
                 response = await req_context.__aenter__()
 
                 self._update_last_token_cookie(response)

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -250,7 +250,7 @@ class BaseApiClient:
         if require_auth:
             await self.ensure_authenticated()
 
-        request_url = self._url.joinpath(url)
+        request_url = self._url.joinpath(url[1:])
         headers = kwargs.get("headers") or self.headers
         _LOGGER.debug("Request url: %s", request_url)
         if not self._verify_ssl:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -160,8 +160,9 @@ def test_base_url(protect_client: ProtectApiClient):
     assert protect_client.ws_url == f"wss://127.0.0.1:0{arg}"
 
     protect_client._port = 443
+    protect_client._update_url()
 
-    assert protect_client.base_url == "https://127.0.0.1:0"
+    assert protect_client.base_url == "https://127.0.0.1"
     assert protect_client.ws_url == f"wss://127.0.0.1{arg}"
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -161,7 +161,7 @@ def test_base_url(protect_client: ProtectApiClient):
 
     protect_client._port = 443
 
-    assert protect_client.base_url == "https://127.0.0.1"
+    assert protect_client.base_url == "https://127.0.0.1:0"
     assert protect_client.ws_url == f"wss://127.0.0.1{arg}"
 
 


### PR DESCRIPTION
Passing URL objects avoids having to have aiohttp create them each request Its a tiny speed up to getting camera snapshots