### PR TITLE
Add method to get release channel from UniFi OS

### DIFF
--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -1653,7 +1653,12 @@ class ProtectApiClient(BaseApiClient):
         """
 
         url = "/api/firmware/update"
-        response = await self.request("get", url=url, require_auth=True, auto_close=False)
+        response = await self.request(
+            "get",
+            url=url,
+            require_auth=True,
+            auto_close=False,
+        )
         try:
             if response.status != 200:
                 reason = await get_response_reason(response)
@@ -1675,5 +1680,5 @@ class ProtectApiClient(BaseApiClient):
 
         if data is not None:
             json_data: Union[list[Any], dict[str, Any]] = orjson.loads(data)
-            return json_data["channel"]
+            return cast(str, json_data["channel"])
         return None

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -1679,6 +1679,6 @@ class ProtectApiClient(BaseApiClient):
             raise
 
         if data is not None:
-            json_data: Union[list[Any], dict[str, Any]] = orjson.loads(data)
+            json_data: dict[str, Any] = orjson.loads(data)
             return cast(str, json_data["channel"])
         return None


### PR DESCRIPTION
UniFi OS access is mostly locked down to superadmin users, but it does not hurt to at least try to check to see what the release channel is for the console to warn users about EA if they do not know. 