### PR TITLE
Add persistent sessions

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -195,6 +195,7 @@ platformdirs==4.2.0
     #   black
     #   mkdocs
     #   mkdocstrings
+    #   pyunifiprotect (pyproject.toml)
 pluggy==1.4.0
     # via pytest
 prompt-toolkit==3.0.43

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,18 +34,19 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
+    'async-timeout; python_version < "3.11"',
     "aiofiles",
     "aiohttp",
-    "yarl>=1.9",
     "aioshutil",
-    'async-timeout; python_version < "3.11"',
     "dateparser",
     "orjson",
     "packaging",
     "pillow",
+    "platformdirs",
     "pydantic!=1.9.1",
     "pyjwt",
     "typer[all]>0.6",
+    "yarl>=1.9",
 ]
 
 [project.urls]

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -491,7 +491,11 @@ class BaseApiClient:
         """Update the last token cookie."""
 
         csrf_token = response.headers.get("x-csrf-token")
-        if csrf_token is not None and csrf_token != self.headers.get("x-csrf-token"):
+        if (
+            csrf_token is not None
+            and self.headers
+            and csrf_token != self.headers.get("x-csrf-token")
+        ):
             self.set_header("x-csrf-token", csrf_token)
             await self._update_last_token_cookie(response)
 
@@ -528,7 +532,7 @@ class BaseApiClient:
         config["sessions"][session_hash] = {
             "metadata": dict(cookie),
             "value": cookie.value,
-            "csrf": self.headers.get("x-csrf-token"),
+            "csrf": self.headers.get("x-csrf-token") if self.headers else None,
         }
 
         async with aiofiles.open(self.config_file, "wb") as f:

--- a/pyunifiprotect/cli/__init__.py
+++ b/pyunifiprotect/cli/__init__.py
@@ -161,8 +161,11 @@ def main(
         protect._bootstrap = await protect.get_bootstrap()
         await protect.close_session()
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(update())
+    if sys.version_info >= (3, 11):
+        asyncio.run(update())
+    else:
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(update())
     ctx.obj = CliContext(protect=protect, output_format=output_format)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,6 +70,8 @@ pexpect==4.9.0
     # via ipython
 pillow==10.2.0
     # via pyunifiprotect (pyproject.toml)
+platformdirs==4.2.0
+    # via pyunifiprotect (pyproject.toml)
 prompt-toolkit==3.0.43
     # via ipython
 ptyprocess==0.7.0


### PR DESCRIPTION
Something I have wanted to support for a file since UniFi OS gets funky and returns 401 as a rate limit sometimes. 

* Adds `platformdirs` for getting the correct user cache / config directories
* Stores and loads `TOKEN` cookies to disk so `ProtectApiClient` can have persistent sessions. If you run `unifi-protect` 5-10 times rapidly, it will not randomly get a 401 since it does not issue a login each time. 
* Refactors how headers are handed so `cookie` / `x-csrf-token` are not randomly accidently deleted
* Fixes deprecation warning in CLI interface (replace `asyncio.get_event_loop` with `asyncio.run` for newer versions of Python)
* Set `x-csrf-token` on every request

This will require a HA side change to redirect the config directory to correct location. 