### PR TITLE
Add volume/repeat to play for chime

### DIFF
--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -1588,10 +1588,32 @@ class ProtectApiClient(BaseApiClient):
             json={"auto": True},
         )
 
-    async def play_speaker(self, device_id: str) -> None:
+    async def play_speaker(
+        self,
+        device_id: str,
+        *,
+        volume: int | None = None,
+        repeat_times: int | None = None,
+    ) -> None:
         """Plays chime tones on a chime"""
 
-        await self.api_request(f"chimes/{device_id}/play-speaker", method="post")
+        data: dict[str, Any] | None = None
+        if volume or repeat_times:
+            chime = self.bootstrap.chimes.get(device_id)
+            if chime is None:
+                raise BadRequest("Invalid chime ID %s", device_id)
+
+            data = {
+                "volume": volume or chime.volume,
+                "repeatTimes": repeat_times or chime.repeat_times,
+                "trackNo": chime.track_no,
+            }
+
+        await self.api_request(
+            f"chimes/{device_id}/play-speaker",
+            method="post",
+            json=data,
+        )
 
     async def play_buzzer(self, device_id: str) -> None:
         """Plays chime tones on a chime"""

--- a/pyunifiprotect/cli/base.py
+++ b/pyunifiprotect/cli/base.py
@@ -46,8 +46,7 @@ def run(ctx: typer.Context, func: Coroutine[Any, Any, T]) -> T:
     runner = asyncio.run
     if sys.version_info < (3, 11):
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(update())
-        runner = loop.run_until_complete
+        runner = loop.run_until_complete  # type: ignore[assignment]
 
     try:
         return runner(callback())

--- a/pyunifiprotect/cli/base.py
+++ b/pyunifiprotect/cli/base.py
@@ -4,6 +4,7 @@ import asyncio
 from collections.abc import Callable, Coroutine, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
+import sys
 from typing import Any, Optional, TypeVar
 
 import orjson
@@ -42,9 +43,14 @@ def run(ctx: typer.Context, func: Coroutine[Any, Any, T]) -> T:
         await ctx.obj.protect.close_session()
         return return_value
 
-    loop = asyncio.get_event_loop()
+    runner = asyncio.run
+    if sys.version_info < (3, 11):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(update())
+        runner = loop.run_until_complete
+
     try:
-        return loop.run_until_complete(callback())
+        return runner(callback())
     except (BadRequest, ValidationError, StreamError, NvrError) as err:
         typer.secho(str(err), fg="red")
         raise typer.Exit(1) from err

--- a/pyunifiprotect/cli/chimes.py
+++ b/pyunifiprotect/cli/chimes.py
@@ -138,12 +138,16 @@ def set_volume(
 
 
 @app.command()
-def play(ctx: typer.Context) -> None:
+def play(
+    ctx: typer.Context,
+    volume: Optional[int] = typer.Option(None, "-v", "--volume", min=1, max=100),
+    repeat_times: Optional[int] = typer.Option(None, "-r", "--repeat", min=1, max=6),
+) -> None:
     """Plays chime tone."""
 
     base.require_device_id(ctx)
     obj: Chime = ctx.obj.device
-    base.run(ctx, obj.play())
+    base.run(ctx, obj.play(volume=volume, repeat_times=repeat_times))
 
 
 @app.command()

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -3104,10 +3104,15 @@ class Chime(ProtectAdoptableDeviceModel):
 
         await self.queue_update(callback)
 
-    async def play(self) -> None:
+    async def play(
+        self,
+        *,
+        volume: int | None = None,
+        repeat_times: int | None = None,
+    ) -> None:
         """Plays chime tone"""
 
-        await self.api.play_speaker(self.id)
+        await self.api.play_speaker(self.id, volume=volume, repeat_times=repeat_times)
 
     async def play_buzzer(self) -> None:
         """Plays chime buzzer"""

--- a/tests/data/test_chime.py
+++ b/tests/data/test_chime.py
@@ -194,6 +194,31 @@ async def test_chime_play(chime_obj: Optional[Chime]):
     chime_obj.api.api_request.assert_called_with(
         f"chimes/{chime_obj.id}/play-speaker",
         method="post",
+        json=None,
+    )
+
+
+@pytest.mark.skipif(not TEST_CHIME_EXISTS, reason="Missing testdata")
+@pytest.mark.asyncio()
+async def test_chime_play_with_options(chime_obj: Optional[Chime]):
+    if chime_obj is None:
+        pytest.skip("No chime_obj obj found")
+
+    chime_obj.volume = 100
+    chime_obj.repeat_times = 1
+    chime_obj.track_no = 1
+    chime_obj.api.api_request.reset_mock()
+
+    await chime_obj.play(volume=50)
+
+    chime_obj.api.api_request.assert_called_with(
+        f"chimes/{chime_obj.id}/play-speaker",
+        method="post",
+        json={
+            "volume": 50,
+            "repeatTimes": 1,
+            "trackNo": 1,
+        },
     )
 
 


### PR DESCRIPTION
* Adds `repeat_times` and `volume` options to `play_speaker` / `play` for API / Chime obj / CLI

trackNo not added yet since there are no alternative tracks or ways to add them.