### PR TITLE
Allow restoring use_global flag in set_privacy

### DIFF
--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -2344,6 +2344,7 @@ class Camera(ProtectMotionDeviceModel):
         enabled: bool,
         mic_level: Optional[int] = None,
         recording_mode: Optional[RecordingMode] = None,
+        use_global: Optional[bool] = None,
     ) -> None:
         """Adds/removes a privacy zone that blacks out the whole camera"""
 
@@ -2361,6 +2362,9 @@ class Camera(ProtectMotionDeviceModel):
 
             if recording_mode is not None:
                 self.recording_settings.mode = recording_mode
+
+            if use_global is not None:
+                self.use_global = use_global
 
         await self.queue_update(callback)
 


### PR DESCRIPTION
I toggled the privacy mode for my camera on and then off again in Home Assistant. I was mystified to find that it subsequently stopped recording when it had been recording before.

Turns out the camera previously had `use_global` set to `True`, so that it used the global settings for recording schedule. Changing its recording mode to `NEVER` disabled `use_global`, and it was not correctly restored later.

Add a parameter that will allow a PR in Home Assistant to restore the previous `use_global` flag.