### PR TITLE
Change license from MIT to BUSL-1.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,58 @@
-MIT License
+Business Source License
 
-Copyright (c) 2020 Bjarne Riis
+Copyright (c) 2024 Christopher Bailey
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Change Date: 6 months from release
+Change License: MIT
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Effective on the Change Date, or six months after the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a commercial
+license from the Licensor, its affiliated entities, or authorized resellers, or
+you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works of
+the Licensed Work, are subject to this License. This License applies separately
+for each version of the Licensed Work and the Change Date may vary for each
+version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy of
+the Licensed Work. If you receive the Licensed Work in original or modified form
+from a third party, the terms and conditions set forth in this License apply to
+your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other versions
+of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of Licensor or
+its affiliates (provided that you may use a trademark or logo of Licensor as
+expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
+"AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS OR
+IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+
+
+Additional Use Grants
+
+For all use cases, this software is considered licensed as the Change License
+and may be used under those terms. There are only two exceptions that are not
+granted usage:
+
+* Ubiquiti may not use the Licensed Work for any "professional" use, including,
+  but not limited to development, tooling or documentation
+* The Licensed Work may not be forked and used for the purpose of making any
+  kind of add-on, integration or component for Home Assistant. Third party or
+  otherwise. The only version of the Licensed Work that may be used in Home
+  Assistant (before the Change Date) is original one.

--- a/LICENSE.CHANGE
+++ b/LICENSE.CHANGE
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,13 @@ maintainers = [
     {name="Christopher Bailey", email="cbailey@mort.is"},
     {name="J. Nick Koston", email="nick@koston.org"},
 ]
-license = {text="MIT"}
+license = {file = "LICENSE"}
 keywords = ["UniFiProtect", "UniFi Protect", "Surveilance", "UniFi", "Home Assistant", "Python"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
-    "License :: OSI Approved :: MIT License",
+    "License :: Business Source License 1.1 (BUSL-1.1)",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
-    "License :: Business Source License 1.1 (BUSL-1.1)",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
I have put a lot of thought into this and decided to make this change to protect this project from outside sources. As a result, I am purposing of changing the license from MIT to BUSL-1.1.

For nearly all possible use cases, I want to make it very clear, this project is **still** MIT. Anyone that wants to make derivative works or use the project may do so.

The license is being changed to BUSL to prevent the two following use cases:

### Ubiquiti may not use this library in any capacity

Internally for development, for tooling, or for documentations or recommendations to users. Ubiquiti has been increasingly hostile towards local only access. They are so insistent on trying to create a facade they support "local only", but then lock more things behind Remote Access and their cloud. As long as they want to try to gaslight the community and keep telling them "just enable Remote Access" to access local only features, they cannot use this library in any capacity. Just in case they happen to already use it.

### This library may not be used for Home Assistant except if it comes _from this repo_

It may not be forked and published to be used in HA. Nabu Casa employees have made [threats to try to cut this project out of Home Assistant](https://github.com/AngellusMortis/pyunifiprotect/pull/243#issuecomment-1281627815) just because they disagree with how software is written for this project. They have also tried to force people and projects to [not allow the usage of their software in other projects](https://github.com/NixOS/nixpkgs/pull/126326#issuecomment-860047453) as well. The more I think about the more that is really not okay. If Home Assistant does not like how `unifiprotect` is managed, they can kick me out of being a code owner, but they may not benefit from my efforts of building a Python API for UniFi Protect as a result. If they want to micromanage every single aspect of code in Home Assistant, they can build their own Python API for UniFi Protect. Nabu Casa always speaks to how they support open source, but then they allow their employees to try to bully other projects into following their rules and their standards. 

I know BUSL and other "source available" licenses are often very controversial because it goes against the absolutist nature of OSI, but OSI has a really short-sighted view on how the world works. In a perfect world, OSI licenses should work. There is no reason MIT should not "just work" for everyone. But the reality is that larger groups will always use their influence and control to bully smaller groups. 

To show that I mean what I say, the Change Date for BUSL is only 6 months, which is much lower than the required 4 years. This means if for whatever reason, this library stops being maintained, it can quickly be forked and transferred to a new owner if they choose to. 